### PR TITLE
Member & Couple Domain 구현

### DIFF
--- a/backend/src/main/java/com/kongdak/KongdakApplication.java
+++ b/backend/src/main/java/com/kongdak/KongdakApplication.java
@@ -2,7 +2,9 @@ package com.kongdak;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class KongdakApplication {
 

--- a/backend/src/main/java/com/kongdak/config/SecurityConfig.java
+++ b/backend/src/main/java/com/kongdak/config/SecurityConfig.java
@@ -1,0 +1,15 @@
+package com.kongdak.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    // 소셜 로그인만 이용하니까 사실 필요가 없다.
+//    @Bean
+//    public PasswordEncoder passwordEncoder(){
+//        return new BCryptPasswordEncoder();
+//    }
+}

--- a/backend/src/main/java/com/kongdak/controller/CoupleController.java
+++ b/backend/src/main/java/com/kongdak/controller/CoupleController.java
@@ -1,0 +1,44 @@
+package com.kongdak.controller;
+
+import com.kongdak.controller.dto.CoupleConnectRequest;
+import com.kongdak.controller.dto.CoupleResponse;
+import com.kongdak.domain.couple.CoupleService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/couples")
+@RequiredArgsConstructor
+public class CoupleController {
+
+    private final CoupleService coupleService;
+
+    @PostMapping
+    public ResponseEntity<CoupleResponse> connect(@RequestBody CoupleConnectRequest request,
+                                                  @AuthenticationPrincipal UserDetails userDetails) {
+        CoupleResponse response = coupleService.connect(
+                Long.parseLong(userDetails.getUsername()),
+                request.partnerId(),
+                request.anniversaryDate()
+        );
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @PatchMapping("/{coupleId}/disconnect")
+    public ResponseEntity<Void> disconnect(@PathVariable Long coupleId,
+                                           @AuthenticationPrincipal UserDetails userDetails) {
+        coupleService.disconnect(coupleId, Long.parseLong(userDetails.getUsername()));
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping("/{coupleId}/restore")
+    public ResponseEntity<Void> restore(@PathVariable Long coupleId,
+                                        @AuthenticationPrincipal UserDetails userDetails) {
+        coupleService.restore(coupleId, Long.parseLong(userDetails.getUsername()));
+        return ResponseEntity.ok().build();
+    }
+}

--- a/backend/src/main/java/com/kongdak/controller/MemberController.java
+++ b/backend/src/main/java/com/kongdak/controller/MemberController.java
@@ -1,0 +1,44 @@
+package com.kongdak.controller;
+
+import com.kongdak.controller.dto.MemberResponse;
+import com.kongdak.controller.dto.UpdateNicknameRequest;
+import com.kongdak.domain.member.Member;
+import com.kongdak.domain.member.MemberService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/members")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @GetMapping
+    public ResponseEntity<MemberResponse> getMemberInfo(@AuthenticationPrincipal UserDetails userDetails) {
+        Member member = memberService.findMemberById(Long.parseLong(userDetails.getUsername()));
+        return ResponseEntity.ok(MemberResponse.from(member));
+    }
+
+    @PatchMapping("/nickname")
+    public ResponseEntity<MemberResponse> updateNickname(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestBody @Valid UpdateNicknameRequest request) {
+
+        Member member = memberService.updateNickname(
+                Long.parseLong(userDetails.getUsername()),
+                request.nickname()
+        );
+        return ResponseEntity.ok(MemberResponse.from(member));
+    }
+
+    @DeleteMapping
+    public ResponseEntity<Void> deactivateMember(@AuthenticationPrincipal UserDetails userDetails) {
+        memberService.deactivateMember(Long.parseLong(userDetails.getUsername()));
+        return ResponseEntity.ok().build();
+    }
+}

--- a/backend/src/main/java/com/kongdak/controller/dto/CoupleConnectRequest.java
+++ b/backend/src/main/java/com/kongdak/controller/dto/CoupleConnectRequest.java
@@ -1,0 +1,6 @@
+package com.kongdak.controller.dto;
+
+import java.time.LocalDateTime;
+
+public record CoupleConnectRequest(Long partnerId, LocalDateTime anniversaryDate) {
+}

--- a/backend/src/main/java/com/kongdak/controller/dto/CoupleInfo.java
+++ b/backend/src/main/java/com/kongdak/controller/dto/CoupleInfo.java
@@ -1,0 +1,23 @@
+package com.kongdak.controller.dto;
+
+import com.kongdak.domain.couple.Couple;
+
+import java.time.LocalDateTime;
+
+public record CoupleInfo(
+        Long coupleId,
+        Long partnerId,
+        LocalDateTime connectedAt,
+        LocalDateTime anniversaryDate,
+        boolean isConnected
+) {
+    public static CoupleInfo from(Couple couple, Long memberId) {
+        return new CoupleInfo(
+                couple.getId(),
+                couple.getPartnerId(memberId),
+                couple.getConnectedAt(),
+                couple.getAnniversaryDate(),
+                couple.isConnected()
+        );
+    }
+}

--- a/backend/src/main/java/com/kongdak/controller/dto/CoupleResponse.java
+++ b/backend/src/main/java/com/kongdak/controller/dto/CoupleResponse.java
@@ -1,0 +1,23 @@
+package com.kongdak.controller.dto;
+
+import com.kongdak.domain.couple.Couple;
+
+import java.time.LocalDateTime;
+
+public record CoupleResponse(
+        Long coupleId,
+        Long partnerId,
+        LocalDateTime connectedAt,
+        LocalDateTime anniversaryDate,
+        boolean isConnected
+) {
+    public static CoupleResponse from(Couple couple, Long memberId) {
+        return new CoupleResponse(
+                couple.getId(),
+                couple.getPartnerId(memberId),
+                couple.getConnectedAt(),
+                couple.getAnniversaryDate(),
+                couple.isConnected()
+        );
+    }
+}

--- a/backend/src/main/java/com/kongdak/controller/dto/MemberCreateRequest.java
+++ b/backend/src/main/java/com/kongdak/controller/dto/MemberCreateRequest.java
@@ -1,0 +1,9 @@
+package com.kongdak.controller.dto;
+
+import com.kongdak.domain.member.OAuthProvider;
+
+public record MemberCreateRequest(
+    String email,
+    String nickname,
+    OAuthProvider oauthProvider) {
+}

--- a/backend/src/main/java/com/kongdak/controller/dto/MemberResponse.java
+++ b/backend/src/main/java/com/kongdak/controller/dto/MemberResponse.java
@@ -1,0 +1,25 @@
+package com.kongdak.controller.dto;
+
+import com.kongdak.domain.member.Member;
+import com.kongdak.domain.member.OAuthProvider;
+
+public record MemberResponse(
+        Long memberId,
+        String email,
+        String nickname,
+        OAuthProvider oAuthProvider,
+        boolean isActive,
+        CoupleInfo coupleInfo
+
+) {
+    public static MemberResponse from(Member member){
+        return new MemberResponse(
+            member.getId(),
+                member.getEmail(),
+                member.getNickname(),
+                member.getOAuthProvider(),
+                member.isActive(),
+                member.getCouple() != null ? CoupleInfo.from(member.getCouple(), member.getId()) : null
+        );
+    }
+}

--- a/backend/src/main/java/com/kongdak/controller/dto/UpdateNicknameRequest.java
+++ b/backend/src/main/java/com/kongdak/controller/dto/UpdateNicknameRequest.java
@@ -1,0 +1,12 @@
+package com.kongdak.controller.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record UpdateNicknameRequest(
+        @NotBlank(message = "Nickname cannot be blanck")
+        @Size(min = 2, max = 20, message = "Nickname must be between 2 and 20 characters")
+        String nickname
+) {
+
+}

--- a/backend/src/main/java/com/kongdak/domain/BaseTimeEntity.java
+++ b/backend/src/main/java/com/kongdak/domain/BaseTimeEntity.java
@@ -1,0 +1,24 @@
+package com.kongdak.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/backend/src/main/java/com/kongdak/domain/couple/Couple.java
+++ b/backend/src/main/java/com/kongdak/domain/couple/Couple.java
@@ -1,0 +1,80 @@
+package com.kongdak.domain.couple;
+
+import com.kongdak.domain.BaseTimeEntity;
+import com.kongdak.domain.member.Member;
+import com.kongdak.global.exception.BusinessException;
+import com.kongdak.global.exception.ErrorCode;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Couple extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne
+    @JoinColumn(name = "member1_id")
+    private Member member1;
+
+    @OneToOne
+    @JoinColumn(name = "member2_id")
+    private Member member2;
+
+    @Column(nullable = false)
+    private LocalDateTime connectedAt;
+
+    private LocalDateTime anniversaryDate;
+
+    @Column(nullable = false)
+    private boolean isConnected = true;
+
+    private LocalDateTime disconnectedAt;
+
+    @Builder
+    public Couple(Member member1, Member member2, LocalDateTime anniversaryDate) {
+        this.member1 = member1;
+        this.member2 = member2;
+        this.anniversaryDate = anniversaryDate;
+    }
+
+    // 파트너 ID를 가져오는 메서드
+    public Long getPartnerId(Long memberId) {
+        if (member1.getId().equals(memberId)) {
+            return member2.getId();
+        }
+        return member1.getId();
+    }
+
+    public void disconnect(){
+        this.isConnected = false;
+        this.disconnectedAt = LocalDateTime.now();
+    }
+
+    public void restore(){
+        validateCanRestore();
+        this.isConnected = true;
+        this.disconnectedAt = null;
+    }
+
+    public boolean canRestore() {
+        if (disconnectedAt == null) {
+            return false;
+        }
+        return ChronoUnit.DAYS.between(disconnectedAt, LocalDateTime.now()) <= 50;
+    }
+
+    private void validateCanRestore() {
+        if (!canRestore()) {
+            throw new BusinessException(ErrorCode.CANNOT_RESTORE_COUPLE);
+        }
+    }
+}

--- a/backend/src/main/java/com/kongdak/domain/couple/CoupleRepository.java
+++ b/backend/src/main/java/com/kongdak/domain/couple/CoupleRepository.java
@@ -1,0 +1,15 @@
+package com.kongdak.domain.couple;
+
+import com.kongdak.domain.member.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface CoupleRepository extends JpaRepository<Couple, Long> {
+    Optional<Couple> findByMember1OrMember2(Member member1, Member member2);
+
+    boolean existsByMember1OrMember2(Member member1, Member member2);
+
+}

--- a/backend/src/main/java/com/kongdak/domain/couple/CoupleService.java
+++ b/backend/src/main/java/com/kongdak/domain/couple/CoupleService.java
@@ -1,0 +1,73 @@
+package com.kongdak.domain.couple;
+
+import com.kongdak.controller.dto.CoupleResponse;
+import com.kongdak.domain.member.Member;
+import com.kongdak.domain.member.MemberService;
+import com.kongdak.global.exception.BusinessException;
+import com.kongdak.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class CoupleService {
+    private final CoupleRepository coupleRepository;
+    private final MemberService memberService;
+
+    @Transactional
+    public CoupleResponse connect(Long memberId, Long partnerId, LocalDateTime anniversaryDate) {
+        Member member = memberService.findMemberById(memberId);
+        Member partner = memberService.findMemberById(partnerId);
+
+        validateConnection(member, partner);
+
+        Couple couple = Couple.builder()
+                .member1(member)
+                .member2(partner)
+                .anniversaryDate(anniversaryDate)
+                .build();
+
+        coupleRepository.save(couple);
+        return CoupleResponse.from(couple, memberId);
+    }
+
+    @Transactional
+    public void disconnect(Long coupleId, Long memberId) {
+        Couple couple = findCoupleById(coupleId);
+        validateMemberInCouple(couple, memberId);
+        couple.disconnect();
+    }
+
+    @Transactional
+    public void restore(Long coupleId, Long memberId) {
+        Couple couple = findCoupleById(coupleId);
+        validateMemberInCouple(couple, memberId);
+        couple.restore();
+    }
+
+    public Couple findCoupleById(Long coupleId) {
+        return coupleRepository.findById(coupleId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.COUPLE_NOT_FOUND));
+
+    }
+
+    private void validateConnection(Member member, Member partner) {
+        if (coupleRepository.existsByMember1OrMember2(member, member)) {
+            throw new BusinessException(ErrorCode.MEMBER_ALREADY_COUPLED);
+        }
+        if (coupleRepository.existsByMember1OrMember2(partner, partner)) {
+            throw new BusinessException(ErrorCode.PARTNER_ALREADY_COUPLED);
+        }
+    }
+
+    private void validateMemberInCouple(Couple couple, Long memberId) {
+        if (!couple.getMember1().getId().equals(memberId) &&
+                !couple.getMember2().getId().equals(memberId)) {
+            throw new BusinessException(ErrorCode.NOT_COUPLE_MEMBER);
+        }
+    }
+}

--- a/backend/src/main/java/com/kongdak/domain/member/Member.java
+++ b/backend/src/main/java/com/kongdak/domain/member/Member.java
@@ -2,6 +2,8 @@ package com.kongdak.domain.member;
 
 import com.kongdak.domain.BaseTimeEntity;
 import com.kongdak.domain.couple.Couple;
+import com.kongdak.global.exception.BusinessException;
+import com.kongdak.global.exception.ErrorCode;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -40,8 +42,18 @@ public class Member extends BaseTimeEntity {
         this.oAuthProvider = oAuthProvider;
     }
 
-    public void updateNickname(String nickname){
+    public void updateNickname(String nickname) {
+        validateNickname(nickname);
         this.nickname = nickname;
+    }
+
+    private void validateNickname(String nickname) {
+        if (nickname == null || nickname.trim().isEmpty()) {
+            throw new BusinessException(ErrorCode.INVALID_NICKNAME);
+        }
+        if (nickname.length() < 2 || nickname.length() > 20) {
+            throw new BusinessException(ErrorCode.INVALID_NICKNAME_LENGTH);
+        }
     }
 
     public void deactivate(){

--- a/backend/src/main/java/com/kongdak/domain/member/Member.java
+++ b/backend/src/main/java/com/kongdak/domain/member/Member.java
@@ -1,0 +1,54 @@
+package com.kongdak.domain.member;
+
+import com.kongdak.domain.BaseTimeEntity;
+import com.kongdak.domain.couple.Couple;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "members")
+public class Member extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    private String nickname;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private OAuthProvider oAuthProvider;
+
+    @Column(nullable = false)
+    private boolean isActive = true;
+
+    @OneToOne(mappedBy = "member")
+    private Couple couple;
+
+    @Builder
+    public Member(String email, String nickname, OAuthProvider oAuthProvider) {
+        this.email = email;
+        this.nickname = nickname;
+        this.oAuthProvider = oAuthProvider;
+    }
+
+    public void updateNickname(String nickname){
+        this.nickname = nickname;
+    }
+
+    public void deactivate(){
+        this.isActive = false;
+    }
+
+    public void activate(){
+        this.isActive = true;
+    }
+}

--- a/backend/src/main/java/com/kongdak/domain/member/MemberRepository.java
+++ b/backend/src/main/java/com/kongdak/domain/member/MemberRepository.java
@@ -1,0 +1,21 @@
+package com.kongdak.domain.member;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByEmail(String email);
+    Optional<Member> findByEmailAndOAuthProvider(String email, OAuthProvider provider);
+
+    boolean existsByEmail(String email);
+
+    @Query("SELECT m FROM Member m WHERE m.isActive = true AND m.couple IS NULL")
+    List<Member> findActiveUnconnectedMembers();
+
+}

--- a/backend/src/main/java/com/kongdak/domain/member/MemberService.java
+++ b/backend/src/main/java/com/kongdak/domain/member/MemberService.java
@@ -1,0 +1,35 @@
+package com.kongdak.domain.member;
+
+import com.kongdak.controller.dto.MemberCreateRequest;
+import com.kongdak.global.exception.BusinessException;
+import com.kongdak.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public Member createmember(MemberCreateRequest request) {
+        validateDuplicateEmail(request.email());
+
+        Member member = Member.builder()
+                .email(request.email())
+                .nickname(request.nickname())
+                .oAuthProvider(request.oauthProvider())
+                .build();
+
+        return memberRepository.save(member);
+    }
+
+    private void validateDuplicateEmail(String email) {
+        if(memberRepository.existsByEmail(email)){
+            throw new BusinessException(ErrorCode.DUPLICATE_EMAIL);
+        }
+    }
+}

--- a/backend/src/main/java/com/kongdak/domain/member/MemberService.java
+++ b/backend/src/main/java/com/kongdak/domain/member/MemberService.java
@@ -32,4 +32,22 @@ public class MemberService {
             throw new BusinessException(ErrorCode.DUPLICATE_EMAIL);
         }
     }
+
+    public Member findMemberById(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+    }
+
+    @Transactional
+    public Member updateNickname(long memberId, String nickname) {
+        Member member = findMemberById(memberId);
+        member.updateNickname(nickname);
+        return member;
+    }
+
+    @Transactional
+    public void deactivateMember(Long memberId) {
+        Member member = findMemberById(memberId);
+        member.deactivate();
+    }
 }

--- a/backend/src/main/java/com/kongdak/domain/member/OAuthProvider.java
+++ b/backend/src/main/java/com/kongdak/domain/member/OAuthProvider.java
@@ -1,0 +1,5 @@
+package com.kongdak.domain.member;
+
+public enum OAuthProvider {
+    KAKAO, GOOGLE
+}

--- a/backend/src/main/java/com/kongdak/global/exception/BusinessException.java
+++ b/backend/src/main/java/com/kongdak/global/exception/BusinessException.java
@@ -1,0 +1,19 @@
+package com.kongdak.global.exception;
+
+public class BusinessException extends RuntimeException{
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public BusinessException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/backend/src/main/java/com/kongdak/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/kongdak/global/exception/ErrorCode.java
@@ -1,0 +1,34 @@
+package com.kongdak.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public enum ErrorCode {
+    // Member 관련 예외
+    MEMBER_NOT_FOUND(404, "M001", "Member not found"),
+    DUPLICATE_EMAIL(400, "M002", "Email already exists"),
+    INVALID_NICKNAME(400, "M003", "Invalid nickname format"),
+
+    // Couple 관련 예외
+    COUPLE_NOT_FOUND(404, "C001", "Couple not found"),
+    ALREADY_IN_COUPLE(400, "C002", "Member is already in a couple relationship"),
+    INVALID_COUPLE_CONNECTION(400, "C003", "Invalid couple connection request"),
+
+    // Auth 관련 예외
+    INVALID_TOKEN(401, "A001", "Invalid token"),
+    EXPIRED_TOKEN(401, "A002", "Token has expired"),
+    UNAUTHORIZED_ACCESS(403, "A003", "Unauthorized access"),
+
+    // 시스템 예외
+    INTERNAL_SERVER_ERROR(500, "S001", "Internal server error");
+
+    private final int status;
+    private final String code;
+    private final String message;
+
+    ErrorCode(int status, String code, String message) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/backend/src/main/java/com/kongdak/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/kongdak/global/exception/ErrorCode.java
@@ -8,11 +8,14 @@ public enum ErrorCode {
     MEMBER_NOT_FOUND(404, "M001", "Member not found"),
     DUPLICATE_EMAIL(400, "M002", "Email already exists"),
     INVALID_NICKNAME(400, "M003", "Invalid nickname format"),
+    INVALID_NICKNAME_LENGTH(400, "M004", "Nickname must be between 2 and 20 characters"),
 
     // Couple 관련 예외
     COUPLE_NOT_FOUND(404, "C001", "Couple not found"),
-    ALREADY_IN_COUPLE(400, "C002", "Member is already in a couple relationship"),
-    INVALID_COUPLE_CONNECTION(400, "C003", "Invalid couple connection request"),
+    MEMBER_ALREADY_COUPLED(400, "C002", "Member is already in a couple relationship"),
+    PARTNER_ALREADY_COUPLED(400, "C003", "Partner is already in a couple relationship"),
+    NOT_COUPLE_MEMBER(403, "C004", "Not a member of this couple"),
+    CANNOT_RESTORE_COUPLE(400, "C005", "Cannot restore couple relationship after grace period"),
 
     // Auth 관련 예외
     INVALID_TOKEN(401, "A001", "Invalid token"),
@@ -21,6 +24,7 @@ public enum ErrorCode {
 
     // 시스템 예외
     INTERNAL_SERVER_ERROR(500, "S001", "Internal server error");
+
 
     private final int status;
     private final String code;

--- a/backend/src/main/java/com/kongdak/global/exception/ErrorResponse.java
+++ b/backend/src/main/java/com/kongdak/global/exception/ErrorResponse.java
@@ -1,0 +1,10 @@
+package com.kongdak.global.exception;
+
+public record ErrorResponse(
+        String code,
+        String message
+) {
+    public static ErrorResponse of(ErrorCode errorCode) {
+        return new ErrorResponse(errorCode.getCode(), errorCode.getMessage());
+    }
+}

--- a/backend/src/main/java/com/kongdak/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/kongdak/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,32 @@
+package com.kongdak.global.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
+        log.error("Business Exception : {}", e.getMessage());
+        ErrorCode errorCode = e.getErrorCode();
+
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ErrorResponse.of(errorCode));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception e) {
+        log.error("Internal Server Error", e);
+        ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
+
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ErrorResponse.of(errorCode));
+    }
+}


### PR DESCRIPTION
# Member & Couple Domain 구현

## 변경 사항
### Member Domain
- Member 엔티티, 레포지토리, 서비스, 컨트롤러 구현
- 회원 가입, 수정, 탈퇴 기능 구현
- 소셜 로그인 위한 기반 구조 구현

### Couple Domain
- Couple 엔티티, 레포지토리, 서비스, 컨트롤러 구현
- 커플 연결, 해제 기능 구현
- 50일 유예기간 및 복구 기능 구현

### Global Exception Handling
- ErrorCode enum 정의
- BusinessException 구현
- GlobalExceptionHandler 구현

### 기타
- BaseTimeEntity 구현으로 생성/수정 시간 자동 관리
- Spring Security 기본 설정 구현
- API 응답 구조 표준화

## 테스트
- [x] Member CRUD 기능
- [x] Couple 연결/해제 기능
- [x] 예외 처리

## 관련 이슈
Closes #16