### PR TITLE
데일리 질문 기능 구현

### DIFF
--- a/backend/src/main/java/com/kongdak/controller/DailyQuestionController.java
+++ b/backend/src/main/java/com/kongdak/controller/DailyQuestionController.java
@@ -1,0 +1,76 @@
+package com.kongdak.controller;
+
+import com.kongdak.controller.dto.request.DailyAnswerRequestDto;
+import com.kongdak.controller.dto.request.EmojiRequestDto;
+import com.kongdak.controller.dto.request.ReplyRequestDto;
+import com.kongdak.controller.dto.response.DailyAnswerResponseDto;
+import com.kongdak.controller.dto.response.DailyQuestionResponseDto;
+import com.kongdak.domain.dailyquestion.DailyQuestionService;
+import com.kongdak.global.response.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/daily-question")
+public class DailyQuestionController {
+    private final DailyQuestionService dailyQuestionService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<DailyQuestionResponseDto>> getDailyQuestion() {
+        return ResponseEntity.ok(ApiResponse.ok(dailyQuestionService.getDailyQuestion()));
+    }
+
+    @GetMapping("/{questionId}/answers")
+    public ResponseEntity<ApiResponse<List<DailyAnswerResponseDto>>> getAnswers(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long questionId) {
+        return ResponseEntity.ok(ApiResponse.ok(
+                dailyQuestionService.getAnswers(memberId, questionId)
+        ));
+    }
+
+    @PostMapping("/{questionId}/answers")
+    public ResponseEntity<ApiResponse<DailyAnswerResponseDto>> createAnswer(
+            @AuthenticationPrincipal Long memberId,  // 인증된 사용자 ID
+            @PathVariable Long questionId,
+            @RequestBody @Valid DailyAnswerRequestDto request) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.created(dailyQuestionService.createAnswer(memberId, questionId, request)));
+    }
+
+    @PatchMapping("/{questionId}/answers/{answerId}/emoji")
+    public ResponseEntity<ApiResponse<Void>> addEmoji(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long questionId,
+            @PathVariable Long answerId,
+            @RequestBody @Valid EmojiRequestDto request) {
+        dailyQuestionService.addEmoji(memberId, answerId, request);
+        return ResponseEntity.ok(ApiResponse.ok());
+    }
+
+    @PostMapping("/{questionId}/replies")
+    public ResponseEntity<ApiResponse<Void>> addReply(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long questionId,
+            @RequestBody @Valid ReplyRequestDto request) {
+        dailyQuestionService.addReply(memberId, questionId, request);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.created());
+    }
+
+    @DeleteMapping("/{questionId}/replies/{replyId}")
+    public ResponseEntity<ApiResponse<Void>> deleteReply(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long questionId,
+            @PathVariable Long replyId) {
+        dailyQuestionService.deleteReply(memberId, questionId, replyId);
+        return ResponseEntity.ok(ApiResponse.ok());
+    }
+}

--- a/backend/src/main/java/com/kongdak/controller/dto/request/DailyAnswerRequestDto.java
+++ b/backend/src/main/java/com/kongdak/controller/dto/request/DailyAnswerRequestDto.java
@@ -1,0 +1,6 @@
+package com.kongdak.controller.dto.request;
+
+public record DailyAnswerRequestDto(
+        String content
+) {
+}

--- a/backend/src/main/java/com/kongdak/controller/dto/request/EmojiRequestDto.java
+++ b/backend/src/main/java/com/kongdak/controller/dto/request/EmojiRequestDto.java
@@ -1,0 +1,6 @@
+package com.kongdak.controller.dto.request;
+
+public record EmojiRequestDto(
+        String emoji
+) {
+}

--- a/backend/src/main/java/com/kongdak/controller/dto/request/ReplyRequestDto.java
+++ b/backend/src/main/java/com/kongdak/controller/dto/request/ReplyRequestDto.java
@@ -1,0 +1,6 @@
+package com.kongdak.controller.dto.request;
+
+public record ReplyRequestDto(
+        String content
+) {
+}

--- a/backend/src/main/java/com/kongdak/controller/dto/response/DailyAnswerResponseDto.java
+++ b/backend/src/main/java/com/kongdak/controller/dto/response/DailyAnswerResponseDto.java
@@ -1,0 +1,21 @@
+package com.kongdak.controller.dto.response;
+
+import com.kongdak.domain.dailyquestion.DailyAnswer;
+
+import java.time.LocalDateTime;
+
+public record DailyAnswerResponseDto(
+        Long answerId,
+        Long memberId,
+        String content,
+        LocalDateTime createdAt
+) {
+    public static DailyAnswerResponseDto from(DailyAnswer answer) {
+        return new DailyAnswerResponseDto(
+                answer.getId(),
+                answer.getMember().getId(),
+                answer.getContent(),
+                answer.getCreatedAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/kongdak/controller/dto/response/DailyQuestionResponseDto.java
+++ b/backend/src/main/java/com/kongdak/controller/dto/response/DailyQuestionResponseDto.java
@@ -1,0 +1,21 @@
+package com.kongdak.controller.dto.response;
+
+import com.kongdak.domain.dailyquestion.DailyQuestion;
+
+import java.time.LocalDateTime;
+
+public record DailyQuestionResponseDto(
+        Long id,
+        String title,
+        boolean isAnswered,
+        LocalDateTime createdAt
+) {
+    public static DailyQuestionResponseDto from(DailyQuestion question) {
+        return new DailyQuestionResponseDto(
+                question.getId(),
+                question.getTitle(),
+                question.isAnswered(),
+                question.getCreatedAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/kongdak/controller/dto/response/ReplyResponseDto.java
+++ b/backend/src/main/java/com/kongdak/controller/dto/response/ReplyResponseDto.java
@@ -1,0 +1,21 @@
+package com.kongdak.controller.dto.response;
+
+import com.kongdak.domain.dailyquestion.AnswerReply;
+
+import java.time.LocalDateTime;
+
+public record ReplyResponseDto(
+        Long replyId,
+        Long memberId,
+        String content,
+        LocalDateTime createdAt
+) {
+    public static ReplyResponseDto from(AnswerReply reply) {
+        return new ReplyResponseDto(
+                reply.getId(),
+                reply.getMember().getId(),
+                reply.getContent(),
+                reply.getCreatedAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/kongdak/domain/dailyquestion/AnswerEmoji.java
+++ b/backend/src/main/java/com/kongdak/domain/dailyquestion/AnswerEmoji.java
@@ -1,0 +1,38 @@
+package com.kongdak.domain.dailyquestion;
+
+
+import com.kongdak.domain.BaseTimeEntity;
+import com.kongdak.domain.member.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "answer_emojis")
+public class AnswerEmoji extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "answer_id")
+    private DailyAnswer answer;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Column(nullable = false)
+    private String emoji;
+
+    @Builder
+    public AnswerEmoji(DailyAnswer answer, Member member, String emoji) {
+        this.answer = answer;
+        this.member = member;
+        this.emoji = emoji;
+    }
+}

--- a/backend/src/main/java/com/kongdak/domain/dailyquestion/AnswerEmojiRepository.java
+++ b/backend/src/main/java/com/kongdak/domain/dailyquestion/AnswerEmojiRepository.java
@@ -1,0 +1,12 @@
+package com.kongdak.domain.dailyquestion;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface AnswerEmojiRepository extends JpaRepository<AnswerEmoji, Long> {
+    // 특정 답변의 이모지 조회
+    List<AnswerEmoji> findByAnswerId(Long answerId);
+}

--- a/backend/src/main/java/com/kongdak/domain/dailyquestion/AnswerReply.java
+++ b/backend/src/main/java/com/kongdak/domain/dailyquestion/AnswerReply.java
@@ -1,0 +1,37 @@
+package com.kongdak.domain.dailyquestion;
+
+import com.kongdak.domain.BaseTimeEntity;
+import com.kongdak.domain.member.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "answer_replies")  // API 명세서의 replies
+public class AnswerReply extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "question_id")
+    private DailyQuestion question;
+
+    @Column(nullable = false)
+    private String content;
+
+    @Builder
+    public AnswerReply(Member member, DailyQuestion question, String content) {
+        this.member = member;
+        this.question = question;
+        this.content = content;
+    }
+}

--- a/backend/src/main/java/com/kongdak/domain/dailyquestion/AnswerReplyRepository.java
+++ b/backend/src/main/java/com/kongdak/domain/dailyquestion/AnswerReplyRepository.java
@@ -1,0 +1,12 @@
+package com.kongdak.domain.dailyquestion;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface AnswerReplyRepository extends JpaRepository<AnswerReply, Long> {
+    // 특정 질문의 모든 댓글 조회
+    List<AnswerReply> findByQuestionId(Long questionId);
+}

--- a/backend/src/main/java/com/kongdak/domain/dailyquestion/DailyAnswer.java
+++ b/backend/src/main/java/com/kongdak/domain/dailyquestion/DailyAnswer.java
@@ -1,0 +1,38 @@
+package com.kongdak.domain.dailyquestion;
+
+import com.kongdak.domain.BaseTimeEntity;
+import com.kongdak.domain.member.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "daily_answers")
+public class DailyAnswer extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "question_id")
+    private DailyQuestion question;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Column(nullable = false)
+    private String content;
+
+    @Builder
+    public DailyAnswer(DailyQuestion question, Member member, String content) {
+        this.question = question;
+        this.member = member;
+        this.content = content;
+    }
+}

--- a/backend/src/main/java/com/kongdak/domain/dailyquestion/DailyAnswerRepository.java
+++ b/backend/src/main/java/com/kongdak/domain/dailyquestion/DailyAnswerRepository.java
@@ -1,0 +1,15 @@
+package com.kongdak.domain.dailyquestion;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface DailyAnswerRepository extends JpaRepository<DailyAnswer, Long> {
+    // 특정 질문에 대한 답변 조회
+    List<DailyAnswer> findByQuestionId(Long questionId);
+    // 특정 멤버의 답변 조회
+    Optional<DailyAnswer> findByQuestionIdAndMemberId(Long questionId, Long memberId);
+}

--- a/backend/src/main/java/com/kongdak/domain/dailyquestion/DailyQuestion.java
+++ b/backend/src/main/java/com/kongdak/domain/dailyquestion/DailyQuestion.java
@@ -1,0 +1,33 @@
+package com.kongdak.domain.dailyquestion;
+
+import com.kongdak.domain.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "daily_questions")
+public class DailyQuestion extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;     // 질문 내용
+
+    @Column(nullable = false)
+    private boolean isAnswered;  // 답변 여부
+
+    @Builder
+    public DailyQuestion(String title) {
+        this.title = title;
+        this.isAnswered = false;
+    }
+}
+

--- a/backend/src/main/java/com/kongdak/domain/dailyquestion/DailyQuestionRepository.java
+++ b/backend/src/main/java/com/kongdak/domain/dailyquestion/DailyQuestionRepository.java
@@ -1,0 +1,19 @@
+package com.kongdak.domain.dailyquestion;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Repository
+public interface DailyQuestionRepository extends JpaRepository<DailyQuestion, Long> {
+    // 오늘의 질문 조회
+    Optional<DailyQuestion> findByCreatedAtBetween(LocalDateTime start, LocalDateTime end);
+}
+
+
+
+
+
+

--- a/backend/src/main/java/com/kongdak/domain/dailyquestion/DailyQuestionService.java
+++ b/backend/src/main/java/com/kongdak/domain/dailyquestion/DailyQuestionService.java
@@ -1,0 +1,152 @@
+package com.kongdak.domain.dailyquestion;
+
+import com.kongdak.controller.dto.request.DailyAnswerRequestDto;
+import com.kongdak.controller.dto.request.EmojiRequestDto;
+import com.kongdak.controller.dto.request.ReplyRequestDto;
+import com.kongdak.controller.dto.response.DailyAnswerResponseDto;
+import com.kongdak.controller.dto.response.DailyQuestionResponseDto;
+import com.kongdak.domain.member.Member;
+import com.kongdak.domain.member.MemberRepository;
+import com.kongdak.global.exception.BusinessException;
+import com.kongdak.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DailyQuestionService {
+    private final DailyQuestionRepository dailyQuestionRepository;
+    private final DailyAnswerRepository dailyAnswerRepository;
+    private final AnswerReplyRepository answerReplyRepository;
+    private final AnswerEmojiRepository answerEmojiRepository;
+    private final MemberRepository memberRepository;
+
+    // 오늘의 질문 조회
+    public DailyQuestionResponseDto getDailyQuestion() {
+        LocalDateTime startOfDay = LocalDateTime.now().withHour(0).withMinute(0).withSecond(0);
+        LocalDateTime endOfDay = startOfDay.plusDays(1);
+
+        DailyQuestion question = dailyQuestionRepository.findByCreatedAtBetween(startOfDay, endOfDay)
+                .orElseThrow(() -> new BusinessException(ErrorCode.QUESTION_NOT_FOUND));
+
+        return DailyQuestionResponseDto.from(question);
+    }
+
+    // 답변 작성
+    @Transactional
+    public DailyAnswerResponseDto createAnswer(Long memberId, Long questionId, DailyAnswerRequestDto request) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+
+        DailyQuestion question = dailyQuestionRepository.findById(questionId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.QUESTION_NOT_FOUND));
+
+        // 이미 답변했는지 확인
+        if (dailyAnswerRepository.findByQuestionIdAndMemberId(questionId, memberId).isPresent()) {
+            throw new BusinessException(ErrorCode.ALREADY_ANSWERED);
+        }
+
+        DailyAnswer answer = DailyAnswer.builder()
+                .question(question)
+                .member(member)
+                .content(request.content())
+                .build();
+
+        DailyAnswer savedAnswer = dailyAnswerRepository.save(answer);
+        return DailyAnswerResponseDto.from(savedAnswer);
+    }
+
+    // 답변 조회 (커플 둘 다 답변했을 때만 상대방 답변 보이도록)
+    public List<DailyAnswerResponseDto> getAnswers(Long memberId, Long questionId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+
+        // 커플 관계 확인
+        Long coupleId = member.getCoupleId();
+        if (coupleId == null) {
+            throw new BusinessException(ErrorCode.COUPLE_NOT_FOUND);
+        }
+
+        List<DailyAnswer> answers = dailyAnswerRepository.findByQuestionId(questionId);
+
+        // 둘 다 답변했는지 확인
+        if (answers.size() == 2) {
+            return answers.stream()
+                    .map(DailyAnswerResponseDto::from)
+                    .collect(Collectors.toList());
+        }
+
+        // 한 명만 답변했을 경우 자신의 답변만 반환
+        return answers.stream()
+                .filter(answer -> answer.getMember().getId().equals(memberId))
+                .map(DailyAnswerResponseDto::from)
+                .collect(Collectors.toList());
+    }
+
+    // 이모지 반응 추가
+    @Transactional
+    public void addEmoji(Long memberId, Long answerId, EmojiRequestDto request) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+
+        DailyAnswer answer = dailyAnswerRepository.findById(answerId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ANSWER_NOT_FOUND));
+
+        // 자신의 답변에는 이모지를 달 수 없음
+        if (answer.getMember().getId().equals(memberId)) {
+            throw new BusinessException(ErrorCode.CANNOT_REACT_TO_OWN_ANSWER);
+        }
+
+        AnswerEmoji answerEmoji = AnswerEmoji.builder()
+                .answer(answer)
+                .member(member)
+                .emoji(request.emoji())
+                .build();
+
+        answerEmojiRepository.save(answerEmoji);
+    }
+
+    // 댓글 작성
+    @Transactional
+    public void addReply(Long memberId, Long questionId, ReplyRequestDto request) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+
+        DailyQuestion question = dailyQuestionRepository.findById(questionId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.QUESTION_NOT_FOUND));
+
+        // 둘 다 답변했는지 확인
+        List<DailyAnswer> answers = dailyAnswerRepository.findByQuestionId(questionId);
+        if (answers.size() != 2) {
+            throw new BusinessException(ErrorCode.BOTH_ANSWERS_REQUIRED);
+        }
+
+        AnswerReply reply = AnswerReply.builder()
+                .member(member)
+                .question(question)
+                .content(request.content())
+                .build();
+
+        answerReplyRepository.save(reply);
+    }
+
+    // 댓글 삭제
+    @Transactional
+    public void deleteReply(Long memberId, Long questionId, Long replyId) {
+        AnswerReply reply = answerReplyRepository.findById(replyId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.REPLY_NOT_FOUND));
+
+        // 자신의 댓글만 삭제 가능
+        if (!reply.getMember().getId().equals(memberId)) {
+            throw new BusinessException(ErrorCode.NOT_YOUR_REPLY);
+        }
+
+        answerReplyRepository.delete(reply);
+    }
+}

--- a/backend/src/main/java/com/kongdak/domain/member/Member.java
+++ b/backend/src/main/java/com/kongdak/domain/member/Member.java
@@ -57,6 +57,10 @@ public class Member extends BaseTimeEntity {
         }
     }
 
+    public Long getCoupleId() {
+        return couple != null ? couple.getId() : null;
+    }
+
     public void deactivate(){
         this.isActive = false;
     }

--- a/backend/src/main/java/com/kongdak/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/kongdak/global/exception/ErrorCode.java
@@ -30,7 +30,14 @@ public enum ErrorCode {
     DUPLICATE_CALENDAR(400, "CL010", "Calendar already exists for this couple"),
     MAX_SCHEDULE_TITLE_LENGTH(400, "CL011", "Schedule title must not exceed 30 characters"),
 
-
+    // DailyQuestion 관련 예외
+    QUESTION_NOT_FOUND(404, "Q001", "Daily question not found"),
+    ANSWER_NOT_FOUND(404, "Q002", "Answer not found"),
+    ALREADY_ANSWERED(400, "Q003", "Already answered today's question"),
+    CANNOT_REACT_TO_OWN_ANSWER(400, "Q004", "Cannot react to your own answer"),
+    BOTH_ANSWERS_REQUIRED(400, "Q005", "Both partners must answer before adding replies"),
+    REPLY_NOT_FOUND(404, "Q006", "Reply not found"),
+    NOT_YOUR_REPLY(403, "Q007", "Cannot delete other's reply"),
 
     // Auth 관련 예외
     INVALID_TOKEN(401, "A001", "Invalid token"),

--- a/backend/src/main/java/com/kongdak/global/response/ApiResponse.java
+++ b/backend/src/main/java/com/kongdak/global/response/ApiResponse.java
@@ -19,7 +19,6 @@ public class ApiResponse<T> {
     public static <T> ApiResponse<T> ok(T data) {
         return new ApiResponse<>(200, true, data, null);
     }
-
     public static <T> ApiResponse<T> ok() {
         return new ApiResponse<>(200, true, null, null);
     }
@@ -28,6 +27,9 @@ public class ApiResponse<T> {
         return new ApiResponse<>(201, true, data, null);
     }
 
+    public static ApiResponse<Void> created() {
+        return new ApiResponse<>(201, true, null, null);
+    }
     public static <T> ApiResponse<T> error(int status, String code, String message) {
         return new ApiResponse<>(status, false, null, new Error(code, message));
     }


### PR DESCRIPTION
# Daily Question 도메인 구현

- [x] 질문, 답변, 댓글, 이모지 반응 엔티티 설계
- [x] 도메인 로직 구현

## API 엔드포인트 구현
- [x] 오늘의 질문 조회 GET /api/daily-question
- [x] 답변 조회 GET /api/daily-question/{questionId}/answers
- [x] 답변 작성 POST /api/daily-question/{questionId}/answers
- [x] 이모지 반응 PATCH /api/daily-question/{questionId}/answers/{answerId}/emoji
- [x] 댓글 작성 POST /api/daily-question/{questionId}/replies
- [x] 댓글 삭제 DELETE /api/daily-question/{questionId}/replies/{replyId}

## 비즈니스 로직
커플 양측의 답변 여부에 따른 조회 권한 관리
양측 모두 답변 완료 시에만 댓글 작성 가능

## TODO
- N+1 문제 해결을 위한 Fetch Join 적용 or Batch Size 로 처리할지 검토