### PR TITLE
커플 다이어리 기능 개발

### DIFF
--- a/backend/src/main/java/com/kongdak/controller/DailyQuestionController.java
+++ b/backend/src/main/java/com/kongdak/controller/DailyQuestionController.java
@@ -18,7 +18,7 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/daily-question")
+@RequestMapping("/api/daily-questions")
 public class DailyQuestionController {
     private final DailyQuestionService dailyQuestionService;
 

--- a/backend/src/main/java/com/kongdak/controller/DiaryController.java
+++ b/backend/src/main/java/com/kongdak/controller/DiaryController.java
@@ -1,0 +1,87 @@
+package com.kongdak.controller;
+
+import com.kongdak.controller.dto.request.CreateDiaryRequest;
+import com.kongdak.controller.dto.request.UpdateDiaryRequest;
+import com.kongdak.controller.dto.response.DiaryDetailResponse;
+import com.kongdak.controller.dto.response.SearchDiaryResponse;
+
+import com.kongdak.domain.diary.DiaryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/diaries")
+@RequiredArgsConstructor
+public class DiaryController {
+
+    private final DiaryService diaryService;
+
+    @PostMapping
+    public ResponseEntity<Long> createDiary(
+            @AuthenticationPrincipal Long memberId,
+            @RequestBody CreateDiaryRequest request
+    ) {
+        Long diaryId = diaryService.createDiary(memberId, request);
+        return ResponseEntity.ok(diaryId);
+    }
+
+    @GetMapping("/{diaryId}")
+    public ResponseEntity<DiaryDetailResponse> getDiary(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long diaryId
+    ) {
+        DiaryDetailResponse response = diaryService.getDiary(memberId, diaryId);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping
+    public ResponseEntity<SearchDiaryResponse> searchDiaries(
+            @AuthenticationPrincipal Long memberId,
+            @PageableDefault Pageable pageable
+    ) {
+        SearchDiaryResponse response = diaryService.searchDiaries(memberId, pageable);
+        return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/{diaryId}")
+    public ResponseEntity<Void> updateDiary(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long diaryId,
+            @RequestBody UpdateDiaryRequest request
+    ) {
+        diaryService.updateDiary(memberId, diaryId, request);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/{diaryId}")
+    public ResponseEntity<Void> deleteDiary(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long diaryId
+    ) {
+        diaryService.deleteDiary(memberId, diaryId);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/{diaryId}/lock")
+    public ResponseEntity<Boolean> acquireLock(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long diaryId
+    ) {
+        boolean acquired = diaryService.acquireLock(diaryId, memberId);
+        return ResponseEntity.ok(acquired);
+    }
+
+    @DeleteMapping("/{diaryId}/lock")
+    public ResponseEntity<Void> releaseLock(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long diaryId
+    ) {
+        diaryService.releaseLock(diaryId, memberId);
+        return ResponseEntity.ok().build();
+    }
+}
+

--- a/backend/src/main/java/com/kongdak/controller/dto/request/CreateDiaryRequest.java
+++ b/backend/src/main/java/com/kongdak/controller/dto/request/CreateDiaryRequest.java
@@ -1,0 +1,26 @@
+package com.kongdak.controller.dto.request;
+
+import com.kongdak.domain.diary.Emotion;
+import com.kongdak.domain.diary.Weather;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record CreateDiaryRequest(
+        @NotNull
+        String content,
+
+        @NotNull
+        Emotion emotion,
+
+        @NotNull
+        Weather weather,
+
+        @NotNull
+        LocalDate diaryDate,
+
+        List<String> photoUrls,
+        List<DecorationCreateRequest> decorations
+) {
+}

--- a/backend/src/main/java/com/kongdak/controller/dto/request/DecorationCreateRequest.java
+++ b/backend/src/main/java/com/kongdak/controller/dto/request/DecorationCreateRequest.java
@@ -1,0 +1,12 @@
+package com.kongdak.controller.dto.request;
+
+import com.kongdak.domain.diary.DecorationType;
+
+public record DecorationCreateRequest(
+        DecorationType type,
+        String content,
+        Integer positionX,
+        Integer positionY,
+        String style
+) {}
+

--- a/backend/src/main/java/com/kongdak/controller/dto/request/DecorationUpdateRequest.java
+++ b/backend/src/main/java/com/kongdak/controller/dto/request/DecorationUpdateRequest.java
@@ -1,0 +1,12 @@
+package com.kongdak.controller.dto.request;
+
+import com.kongdak.domain.diary.DecorationType;
+
+public record DecorationUpdateRequest(
+        Long decorationId,
+        DecorationType type,
+        String content,
+        Integer positionX,
+        Integer positionY,
+        String style
+) {}

--- a/backend/src/main/java/com/kongdak/controller/dto/request/UpdateDiaryRequest.java
+++ b/backend/src/main/java/com/kongdak/controller/dto/request/UpdateDiaryRequest.java
@@ -1,0 +1,21 @@
+package com.kongdak.controller.dto.request;
+
+import com.kongdak.domain.diary.Emotion;
+import com.kongdak.domain.diary.Weather;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public record UpdateDiaryRequest(
+        @NotNull
+        String content,
+
+        @NotNull
+        Emotion emotion,
+
+        @NotNull
+        Weather weather,
+
+        List<String> photoUrls,
+        List<DecorationUpdateRequest> decorations
+) {}

--- a/backend/src/main/java/com/kongdak/controller/dto/response/DailyQuestionResponseDto.java
+++ b/backend/src/main/java/com/kongdak/controller/dto/response/DailyQuestionResponseDto.java
@@ -5,7 +5,7 @@ import com.kongdak.domain.dailyquestion.DailyQuestion;
 import java.time.LocalDateTime;
 
 public record DailyQuestionResponseDto(
-        Long id,
+        Long DailyQuestionId,
         String title,
         boolean isAnswered,
         LocalDateTime createdAt

--- a/backend/src/main/java/com/kongdak/controller/dto/response/DecorationResponse.java
+++ b/backend/src/main/java/com/kongdak/controller/dto/response/DecorationResponse.java
@@ -1,0 +1,24 @@
+package com.kongdak.controller.dto.response;
+
+import com.kongdak.domain.diary.DecorationType;
+import com.kongdak.domain.diary.DiaryDecoration;
+
+public record DecorationResponse(
+        Long decorationId,
+        DecorationType type,
+        String content,
+        Integer positionX,
+        Integer positionY,
+        String style
+) {
+    public static DecorationResponse from(DiaryDecoration decoration) {
+        return new DecorationResponse(
+                decoration.getId(),
+                decoration.getType(),
+                decoration.getContent(),
+                decoration.getPositionX(),
+                decoration.getPositionY(),
+                decoration.getStyle()
+        );
+    }
+}

--- a/backend/src/main/java/com/kongdak/controller/dto/response/DiaryDetailResponse.java
+++ b/backend/src/main/java/com/kongdak/controller/dto/response/DiaryDetailResponse.java
@@ -1,0 +1,43 @@
+package com.kongdak.controller.dto.response;
+
+import com.kongdak.domain.diary.Diary;
+import com.kongdak.domain.diary.Emotion;
+import com.kongdak.domain.diary.Weather;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record DiaryDetailResponse(
+        Long diaryId,
+        String content,
+        Emotion emotion,
+        Weather weather,
+        LocalDate diaryDate,
+        List<PhotoResponse> photos,
+        List<DecorationResponse> decorations,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt,
+        Boolean isEditing,
+        Long editorId
+) {
+    public static DiaryDetailResponse from(Diary diary) {
+        return new DiaryDetailResponse(
+                diary.getId(),
+                diary.getContent(),
+                diary.getEmotion(),
+                diary.getWeather(),
+                diary.getDiaryDate(),
+                diary.getPhotos().stream()
+                        .map(PhotoResponse::from)
+                        .toList(),
+                diary.getDecorations().stream()
+                        .map(DecorationResponse::from)
+                        .toList(),
+                diary.getCreatedAt(),
+                diary.getUpdatedAt(),
+                diary.isEditing(),
+                diary.getEditor() != null ? diary.getEditor().getId() : null
+        );
+    }
+}

--- a/backend/src/main/java/com/kongdak/controller/dto/response/DiaryListResponse.java
+++ b/backend/src/main/java/com/kongdak/controller/dto/response/DiaryListResponse.java
@@ -1,0 +1,35 @@
+package com.kongdak.controller.dto.response;
+
+import com.kongdak.domain.diary.Diary;
+import com.kongdak.domain.diary.Emotion;
+import com.kongdak.domain.diary.Weather;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public record DiaryListResponse(
+        Long diaryId,
+        String content,
+        Emotion emotion,
+        Weather weather,
+        LocalDate diaryDate,
+        String thumbnailUrl,  // 리스트에서는 썸네일만 표시
+        LocalDateTime createdAt
+) {
+    public static DiaryListResponse from(Diary diary) {
+        String thumbnail = diary.getPhotos().isEmpty() ?
+                null :
+                diary.getPhotos().get(0).getThumbnailUrl();
+
+        return new DiaryListResponse(
+                diary.getId(),
+                diary.getContent(),
+                diary.getEmotion(),
+                diary.getWeather(),
+                diary.getDiaryDate(),
+                thumbnail,
+                diary.getCreatedAt()
+        );
+    }
+}
+

--- a/backend/src/main/java/com/kongdak/controller/dto/response/PhotoResponse.java
+++ b/backend/src/main/java/com/kongdak/controller/dto/response/PhotoResponse.java
@@ -1,0 +1,17 @@
+package com.kongdak.controller.dto.response;
+
+import com.kongdak.domain.diary.DiaryPhoto;
+
+public record PhotoResponse(
+        Long photoId,
+        String photoUrl,
+        String thumbnailUrl
+) {
+    public static PhotoResponse from(DiaryPhoto photo) {
+        return new PhotoResponse(
+                photo.getId(),
+                photo.getPhotoUrl(),
+                photo.getThumbnailUrl()
+        );
+    }
+}

--- a/backend/src/main/java/com/kongdak/controller/dto/response/SearchDiaryResponse.java
+++ b/backend/src/main/java/com/kongdak/controller/dto/response/SearchDiaryResponse.java
@@ -1,0 +1,24 @@
+package com.kongdak.controller.dto.response;
+
+import com.kongdak.domain.diary.Diary;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+public record SearchDiaryResponse(
+        List<DiaryListResponse> diaries,
+        int totalPages,
+        long totalElements,
+        boolean hasNext
+) {
+    public static SearchDiaryResponse from(Page<Diary> diaryPage) {
+        return new SearchDiaryResponse(
+                diaryPage.getContent().stream()
+                        .map(DiaryListResponse::from)
+                        .toList(),
+                diaryPage.getTotalPages(),
+                diaryPage.getTotalElements(),
+                diaryPage.hasNext()
+        );
+    }
+}

--- a/backend/src/main/java/com/kongdak/domain/couple/CoupleRepository.java
+++ b/backend/src/main/java/com/kongdak/domain/couple/CoupleRepository.java
@@ -2,6 +2,8 @@ package com.kongdak.domain.couple;
 
 import com.kongdak.domain.member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -9,6 +11,9 @@ import java.util.Optional;
 @Repository
 public interface CoupleRepository extends JpaRepository<Couple, Long> {
     Optional<Couple> findByMember1OrMember2(Member member1, Member member2);
+
+    @Query("SELECT c FROM Couple c WHERE c.member1.id = :memberId OR c.member2.id = :memberId")
+    Optional<Couple> findByMemberId(@Param("memberId") Long memberId);
 
     boolean existsByMember1OrMember2(Member member1, Member member2);
 

--- a/backend/src/main/java/com/kongdak/domain/diary/DecorationType.java
+++ b/backend/src/main/java/com/kongdak/domain/diary/DecorationType.java
@@ -1,0 +1,5 @@
+package com.kongdak.domain.diary;
+
+public enum DecorationType {
+    BOLD, HIGHLIGHT, STICKER
+}

--- a/backend/src/main/java/com/kongdak/domain/diary/Diary.java
+++ b/backend/src/main/java/com/kongdak/domain/diary/Diary.java
@@ -1,0 +1,93 @@
+package com.kongdak.domain.diary;
+
+import com.kongdak.domain.BaseTimeEntity;
+import com.kongdak.domain.couple.Couple;
+import com.kongdak.domain.member.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Diary extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "couple_id")
+    private Couple couple;
+
+    @Column(nullable = false)
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Emotion emotion;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Weather weather;
+
+    @Column(nullable = false)
+    private LocalDate diaryDate;
+
+    private boolean isEditing;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "editor_id")
+    private Member editor;
+
+    @OneToMany(mappedBy = "diary", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<DiaryPhoto> photos = new ArrayList<>();
+
+    @OneToMany(mappedBy = "diary", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<DiaryDecoration> decorations = new ArrayList<>();
+
+    @Builder
+    public Diary(Couple couple, String content, Emotion emotion, Weather weather, LocalDate diaryDate) {
+        this.couple = couple;
+        this.content = content;
+        this.emotion = emotion;
+        this.weather = weather;
+        this.diaryDate = diaryDate;
+    }
+
+    // 수정 메서드
+    public void update(String content, Emotion emotion, Weather weather) {
+        this.content = content;
+        this.emotion = emotion;
+        this.weather = weather;
+    }
+
+    // 편집 잠금
+    public void startEditing(Member editor) {
+        this.isEditing = true;
+        this.editor = editor;
+    }
+
+    // 편집 잠금 해제
+    public void finishEditing() {
+        this.isEditing = false;
+        this.editor = null;
+    }
+
+    // 사진 추가
+    public void addPhoto(DiaryPhoto photo) {
+        this.photos.add(photo);
+        photo.setDiary(this);
+    }
+
+    // 꾸미기 추가
+    public void addDecoration(DiaryDecoration decoration) {
+        this.decorations.add(decoration);
+        decoration.setDiary(this);
+    }
+}

--- a/backend/src/main/java/com/kongdak/domain/diary/DiaryDecoration.java
+++ b/backend/src/main/java/com/kongdak/domain/diary/DiaryDecoration.java
@@ -1,0 +1,49 @@
+package com.kongdak.domain.diary;
+
+import com.kongdak.domain.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DiaryDecoration extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "diary_id")
+    private Diary diary;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private DecorationType type;
+
+    private String content;
+
+    private Integer positionX;
+
+    private Integer positionY;
+
+    @Column(columnDefinition = "json")
+    private String style;
+
+    @Builder
+    public DiaryDecoration(DecorationType type, String content,
+                           Integer positionX, Integer positionY, String style) {
+        this.type = type;
+        this.content = content;
+        this.positionX = positionX;
+        this.positionY = positionY;
+        this.style = style;
+    }
+
+    public void setDiary(Diary diary) {
+        this.diary = diary;
+    }
+}

--- a/backend/src/main/java/com/kongdak/domain/diary/DiaryDecorationRepository.java
+++ b/backend/src/main/java/com/kongdak/domain/diary/DiaryDecorationRepository.java
@@ -1,0 +1,16 @@
+package com.kongdak.domain.diary;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface DiaryDecorationRepository extends JpaRepository<DiaryDecoration, Long> {
+    List<DiaryDecoration> findByDiaryId(Long diaryId);
+
+    @Query("SELECT dd FROM DiaryDecoration dd WHERE dd.diary.id = :diaryId AND dd.diary.couple.id = :coupleId")
+    List<DiaryDecoration> findByDiaryIdAndCoupleId(@Param("diaryId") Long diaryId, @Param("coupleId") Long coupleId);
+
+    void deleteByDiaryId(Long diaryId);
+}

--- a/backend/src/main/java/com/kongdak/domain/diary/DiaryPhoto.java
+++ b/backend/src/main/java/com/kongdak/domain/diary/DiaryPhoto.java
@@ -1,0 +1,37 @@
+package com.kongdak.domain.diary;
+
+import com.kongdak.domain.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DiaryPhoto extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "diary_id")
+    private Diary diary;
+
+    @Column(nullable = false)
+    private String photoUrl;
+
+    private String thumbnailUrl;
+
+    @Builder
+    public DiaryPhoto(String photoUrl, String thumbnailUrl) {
+        this.photoUrl = photoUrl;
+        this.thumbnailUrl = thumbnailUrl;
+    }
+
+    public void setDiary(Diary diary) {
+        this.diary = diary;
+    }
+}

--- a/backend/src/main/java/com/kongdak/domain/diary/DiaryPhotoRepository.java
+++ b/backend/src/main/java/com/kongdak/domain/diary/DiaryPhotoRepository.java
@@ -1,0 +1,19 @@
+package com.kongdak.domain.diary;
+
+import io.lettuce.core.dynamic.annotation.Param;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface DiaryPhotoRepository extends JpaRepository<DiaryPhoto, Long> {
+    List<DiaryPhoto> findByDiaryId(Long diaryId);
+
+    @Query("SELECT dp FROM DiaryPhoto dp WHERE dp.diary.id = :diaryId AND dp.diary.couple.id = :coupleId")
+    List<DiaryPhoto> findDiaryIdAndCoupleId(@Param("diaryId") Long diaryId, @Param("coupleId") Long coupleId);
+
+    void deleteByDiaryId(Long diaryId);
+
+}

--- a/backend/src/main/java/com/kongdak/domain/diary/DiaryRepository.java
+++ b/backend/src/main/java/com/kongdak/domain/diary/DiaryRepository.java
@@ -1,0 +1,49 @@
+package com.kongdak.domain.diary;
+
+import com.kongdak.domain.couple.Couple;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+@Repository
+public interface DiaryRepository extends JpaRepository<Diary, Long> {
+
+    // 특정 날짜의 일기 존재 여부 확인
+    boolean existsByCoupleIdAndDiaryDate(Long coupleId, LocalDate diaryDate);
+
+    Optional<Diary> findByIdAndCoupleId(Long id, Long coupleId);
+    // 특정 달의 일기 목록 조회 (페이징)
+    @Query("SELECT d FROM Diary d WHERE d.couple = :couple " +
+            "AND YEAR(d.diaryDate) = :year " +
+            "AND MONTH(d.diaryDate) = :month " +
+            "ORDER BY d.diaryDate DESC")
+    Page<Diary> findByYearAndMonth(
+            @Param("couple") Couple couple,
+            @Param("year") int year,
+            @Param("month") int month,
+            Pageable pageable
+    );
+
+    // 내용 검색 (페이징)
+    @Query("SELECT d FROM Diary d WHERE d.couple = :couple " +
+            "AND d.content LIKE %:keyword% " +
+            "ORDER BY d.diaryDate DESC")
+    Page<Diary> searchByContent(
+            @Param("couple") Couple couple,
+            @Param("keyword") String keyword,
+            Pageable pageable
+    );
+
+    // 전체 일기 목록 조회 (페이징)
+    Page<Diary> findAllByCoupleIdOrderByDiaryDateDesc(Long coupleId, Pageable pageable);
+
+    // 특정 날짜의 일기 조회
+    Optional<Diary> findByCoupleIdAndDiaryDate(Long coupleId, LocalDate diaryDate);
+}

--- a/backend/src/main/java/com/kongdak/domain/diary/DiaryService.java
+++ b/backend/src/main/java/com/kongdak/domain/diary/DiaryService.java
@@ -1,0 +1,216 @@
+package com.kongdak.domain.diary;
+
+import com.kongdak.controller.dto.request.CreateDiaryRequest;
+import com.kongdak.controller.dto.request.DecorationUpdateRequest;
+import com.kongdak.controller.dto.request.UpdateDiaryRequest;
+import com.kongdak.controller.dto.response.DiaryDetailResponse;
+import com.kongdak.controller.dto.response.SearchDiaryResponse;
+import com.kongdak.domain.couple.CoupleRepository;
+import com.kongdak.domain.member.Member;
+import com.kongdak.domain.member.MemberRepository;
+import com.kongdak.global.exception.BusinessException;
+import com.kongdak.global.exception.ErrorCode;
+import com.kongdak.global.redis.RedisLockRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import com.kongdak.domain.couple.Couple;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DiaryService {
+    private static final long LOCK_DURATION = TimeUnit.MINUTES.toMillis(30);
+
+    private final DiaryRepository diaryRepository;
+    private final DiaryPhotoRepository photoRepository;
+    private final DiaryDecorationRepository decorationRepository;
+    private final MemberRepository memberRepository;
+    private final CoupleRepository coupleRepository;
+    private final RedisLockRepository redisLockRepository;
+
+    @Transactional
+    public Long createDiary(Long memberId, CreateDiaryRequest request) {
+        Member member = getMemberById(memberId);
+        Couple couple = getCoupleByMemberId(memberId);
+
+        // 해당 날짜에 이미 일기가 존재하는지 확인
+        validateDiaryNotExistsForDate(couple.getId(), request.diaryDate());
+
+        // 일기 생성
+        Diary diary = Diary.builder()
+                .couple(couple)
+                .content(request.content())
+                .emotion(request.emotion())
+                .weather(request.weather())
+                .diaryDate(request.diaryDate())
+                .build();
+
+        // 사진 추가
+        if (request.photoUrls() != null) {
+            request.photoUrls().forEach(url -> {
+                DiaryPhoto photo = DiaryPhoto.builder()
+                        .photoUrl(url)
+                        .thumbnailUrl(generateThumbnail(url))
+                        .build();
+                diary.addPhoto(photo);
+            });
+        }
+
+        // 꾸미기 요소 추가
+        if (request.decorations() != null) {
+            request.decorations().forEach(dec -> {
+                DiaryDecoration decoration = DiaryDecoration.builder()
+                        .type(dec.type())
+                        .content(dec.content())
+                        .positionX(dec.positionX())
+                        .positionY(dec.positionY())
+                        .style(dec.style())
+                        .build();
+                diary.addDecoration(decoration);
+            });
+        }
+
+        return diaryRepository.save(diary).getId();
+    }
+
+    @Transactional
+    public void updateDiary(Long memberId, Long diaryId, UpdateDiaryRequest request) {
+        Diary diary = getDiaryByIdAndMemberId(diaryId, memberId);
+        validateDiaryEditable(diary, memberId);
+
+        try {
+            // 기본 정보 업데이트
+            diary.update(request.content(), request.emotion(), request.weather());
+
+            // 사진 업데이트
+            updatePhotos(diary, request.photoUrls());
+
+            // 꾸미기 요소 업데이트
+            updateDecorations(diary, request.decorations());
+        } finally {
+            // 편집 잠금 해제
+            releaseLock(diaryId, memberId);
+        }
+    }
+
+    public DiaryDetailResponse getDiary(Long memberId, Long diaryId) {
+        Couple couple = getCoupleByMemberId(memberId);
+        Diary diary = getDiaryByIdAndCoupleId(diaryId, couple.getId());
+        return DiaryDetailResponse.from(diary);
+    }
+
+    public SearchDiaryResponse searchDiaries(Long memberId, Pageable pageable) {
+        Couple couple = getCoupleByMemberId(memberId);
+        Page<Diary> diaries = diaryRepository.findAllByCoupleIdOrderByDiaryDateDesc(couple.getId(), pageable);
+        return SearchDiaryResponse.from(diaries);
+    }
+
+    @Transactional
+    public void deleteDiary(Long memberId, Long diaryId) {
+        Couple couple = getCoupleByMemberId(memberId);
+        Diary diary = getDiaryByIdAndCoupleId(diaryId, couple.getId());
+        validateDiaryEditable(diary, memberId);
+        diaryRepository.delete(diary);
+    }
+
+    @Transactional
+    public boolean acquireLock(Long diaryId, Long memberId) {
+        String lockKey = "diary:" + diaryId;
+        if (redisLockRepository.acquireLock(lockKey, memberId.toString(), LOCK_DURATION)) {
+            Diary diary = getDiaryByIdAndMemberId(diaryId, memberId);
+            diary.startEditing(getMemberById(memberId));
+            return true;
+        }
+        return false;
+    }
+
+    @Transactional
+    public void releaseLock(Long diaryId, Long memberId) {
+        String lockKey = "diary:" + diaryId;
+        if (redisLockRepository.releaseLock(lockKey, memberId.toString())) {
+            Diary diary = getDiaryByIdAndMemberId(diaryId, memberId);
+            diary.finishEditing();
+        }
+    }
+
+    // Private 헬퍼 메서드
+    private void validateDiaryNotExistsForDate(Long coupleId, LocalDate date) {
+        if (diaryRepository.existsByCoupleIdAndDiaryDate(coupleId, date)) {
+            throw new BusinessException(ErrorCode.DIARY_ALREADY_EXISTS);
+        }
+    }
+
+    private void validateDiaryEditable(Diary diary, Long memberId) {
+        if (diary.isEditing() && !memberId.equals(diary.getEditor().getId())) {
+            throw new BusinessException(ErrorCode.DIARY_BEING_EDITED);
+        }
+    }
+
+    private Member getMemberById(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+    }
+
+    private Couple getCoupleByMemberId(Long memberId) {
+        return coupleRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.COUPLE_NOT_FOUND));
+    }
+
+    private Diary getDiaryByIdAndMemberId(Long diaryId, Long memberId) {
+        Couple couple = getCoupleByMemberId(memberId);
+        return getDiaryByIdAndCoupleId(diaryId, couple.getId());
+    }
+
+    private Diary getDiaryByIdAndCoupleId(Long diaryId, Long coupleId) {
+        return diaryRepository.findByIdAndCoupleId(diaryId, coupleId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.DIARY_NOT_FOUND));
+    }
+
+    private String generateThumbnail(String originalUrl) {
+        // 실제 썸네일 생성 로직 구현 필요
+        return originalUrl + "_thumbnail";
+    }
+
+    private void updatePhotos(Diary diary, List<String> newPhotoUrls) {
+        if (newPhotoUrls == null) return;
+
+        // 기존 사진 삭제
+        diary.getPhotos().clear();
+
+        // 새 사진 추가
+        newPhotoUrls.forEach(url -> {
+            DiaryPhoto photo = DiaryPhoto.builder()
+                    .photoUrl(url)
+                    .thumbnailUrl(generateThumbnail(url))
+                    .build();
+            diary.addPhoto(photo);
+        });
+    }
+
+    private void updateDecorations(Diary diary, List<DecorationUpdateRequest> newDecorations) {
+        if (newDecorations == null) return;
+
+        // 기존 꾸미기 요소 삭제
+        diary.getDecorations().clear();
+
+        // 새 꾸미기 요소 추가
+        newDecorations.forEach(dec -> {
+            DiaryDecoration decoration = DiaryDecoration.builder()
+                    .type(dec.type())
+                    .content(dec.content())
+                    .positionX(dec.positionX())
+                    .positionY(dec.positionY())
+                    .style(dec.style())
+                    .build();
+            diary.addDecoration(decoration);
+        });
+    }
+}

--- a/backend/src/main/java/com/kongdak/domain/diary/Emotion.java
+++ b/backend/src/main/java/com/kongdak/domain/diary/Emotion.java
@@ -1,0 +1,5 @@
+package com.kongdak.domain.diary;
+
+public enum Emotion {
+    HAPPY, SAD, ANGRY, EXCITED, NERVOUS
+}

--- a/backend/src/main/java/com/kongdak/domain/diary/Weather.java
+++ b/backend/src/main/java/com/kongdak/domain/diary/Weather.java
@@ -1,0 +1,6 @@
+package com.kongdak.domain.diary;
+
+public enum Weather {
+    SUNNY, CLOUDY, RAINY, SNOWY
+}
+

--- a/backend/src/main/java/com/kongdak/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/kongdak/global/exception/ErrorCode.java
@@ -39,6 +39,12 @@ public enum ErrorCode {
     REPLY_NOT_FOUND(404, "Q006", "Reply not found"),
     NOT_YOUR_REPLY(403, "Q007", "Cannot delete other's reply"),
 
+    // Diary 관련 예외
+    DIARY_NOT_FOUND(404, "D001", "Diary not found"),
+    DIARY_ALREADY_EXISTS(400, "D002", "Diary already exists for the given date"),
+    DIARY_BEING_EDITED(400, "D003", "Diary is currently being edited by another user"),
+    DIARY_ACCESS_DENIED(403, "D004", "No permission to access this diary"),
+
     // Auth 관련 예외
     INVALID_TOKEN(401, "A001", "Invalid token"),
     EXPIRED_TOKEN(401, "A002", "Token has expired"),

--- a/backend/src/main/java/com/kongdak/global/redis/RedisConfig.java
+++ b/backend/src/main/java/com/kongdak/global/redis/RedisConfig.java
@@ -1,0 +1,25 @@
+package com.kongdak.global.redis;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+
+        // key와 value의 직렬화 방식을 StringRedisSerializer로 설정
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(new StringRedisSerializer());
+
+        return template;
+    }
+}

--- a/backend/src/main/java/com/kongdak/global/redis/RedisLockRepository.java
+++ b/backend/src/main/java/com/kongdak/global/redis/RedisLockRepository.java
@@ -1,0 +1,36 @@
+package com.kongdak.global.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.concurrent.TimeUnit;
+
+@Repository
+@RequiredArgsConstructor
+public class RedisLockRepository {
+    private final StringRedisTemplate redisTemplate;
+
+    public boolean acquireLock(String lockKey, String memberId, long timeoutMillis) {
+        return Boolean.TRUE.equals(
+                redisTemplate.opsForValue()
+                        .setIfAbsent(lockKey, memberId, timeoutMillis, TimeUnit.MILLISECONDS)
+        );
+    }
+
+    public boolean releaseLock(String lockKey, String memberId) {
+        String currentHolder = redisTemplate.opsForValue().get(lockKey);
+        if (memberId.equals(currentHolder)) {
+            return Boolean.TRUE.equals(redisTemplate.delete(lockKey));
+        }
+        return false;
+    }
+
+    public String getLockHolder(String lockKey) {
+        return redisTemplate.opsForValue().get(lockKey);
+    }
+
+    public boolean isLocked(String lockKey) {
+        return redisTemplate.opsForValue().get(lockKey) != null;
+    }
+}


### PR DESCRIPTION
# 커플 다이어리 기능 개발

## Description
커플이 함께 작성하는 다이어리 기능 개발
주요 기능으로는 일기 CRUD, Redis를 활용한 동시성 제어, 사진 및 꾸미기 요소 관리 등

## Changes

### 엔드포인트 구현
- 다이어리 CRUD API 엔드포인트 추가
 - `POST /api/diaries`: 일기 생성
 - `GET /api/diaries/{diaryId}`: 일기 조회
 - `GET /api/diaries`: 일기 목록 조회 (페이징)
 - `PUT /api/diaries/{diaryId}`: 일기 수정
 - `DELETE /api/diaries/{diaryId}`: 일기 삭제
- 편집 잠금 관련 API 추가
 - `POST /api/diaries/{diaryId}/lock`: 락 획득 
 - `DELETE /api/diaries/{diaryId}/lock`: 락 해제

### 서비스 로직 구현
- 커플별 다이어리 CRUD 기능 구현
- Redis를 활용한 분산 락으로 동시성 제어
- 사진 업로드 및 썸네일 생성 기능
- 다이어리 꾸미기 요소 관리
- 하루 한 개 일기 제한 검증 로직

### Repository 구현
- JPA Repository 인터페이스 구현
 - DiaryRepository
 - DiaryPhotoRepository  
 - DiaryDecorationRepository
 - CoupleRepository
- Redis Repository 구현
 - RedisLockRepository

## Related Issues
This closes #32 

## TODO
- Redis 상세설정 필요.
- 이미지 저장소(S3 등) 설정 필요
