### PR TITLE
JWT 처리 및 email 로직 변경

### DIFF
--- a/backend/src/main/java/com/kongdak/config/SecurityConfig.java
+++ b/backend/src/main/java/com/kongdak/config/SecurityConfig.java
@@ -30,7 +30,7 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
         http
-                .cors(cors -> cors.configure(http))
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .csrf(csrf -> csrf.disable())
                 .formLogin(form -> form.disable())
                 .httpBasic(basic -> basic.disable())
@@ -46,7 +46,7 @@ public class SecurityConfig {
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .authorizeHttpRequests(auth -> auth
 //                        .requestMatchers("/api/auth/**", "/api/oauth2/**", "/oauth2/**").permitAll()
-                        .requestMatchers("/auth/**", "/oauth2/**", "/oauth2/**").permitAll()
+                        .requestMatchers("/auth/**", "/api/**", "/oauth2/**").permitAll()
                         // Swagger UI 관련 경로 허용
                         .requestMatchers(
                                 "/v3/api-docs",
@@ -63,11 +63,12 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.addAllowedOriginPattern("*");  // 개발 환경에서 모든 출처 허용
-        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.addAllowedOriginPattern("*");  // 개발 환경에서는 이렇게 허용
+        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
         configuration.setAllowedHeaders(Arrays.asList("*"));
-        configuration.setAllowCredentials(true);  // JWT, OAuth 사용을 위한 인증 정보 허용
-        configuration.setMaxAge(3600L);  // 프리플라이트 요청 캐시 시간 설정
+        configuration.setExposedHeaders(Arrays.asList("Access-Control-Allow-Origin", "Access-Control-Allow-Credentials"));
+        configuration.setAllowCredentials(true);
+        configuration.setMaxAge(3600L);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);

--- a/backend/src/main/java/com/kongdak/controller/MemberController.java
+++ b/backend/src/main/java/com/kongdak/controller/MemberController.java
@@ -46,7 +46,7 @@ public class MemberController {
             @Parameter(description = "변경할 닉네임 정보")
             @RequestBody @Valid UpdateNicknameRequest request) {
         Member member = memberService.updateNickname(
-                Long.parseLong(userDetails.getUsername()),
+                userDetails.getUsername(),
                 request.nickname()
         );
         return BaseResponse.ok(MemberResponse.from(member));

--- a/backend/src/main/java/com/kongdak/domain/member/MemberService.java
+++ b/backend/src/main/java/com/kongdak/domain/member/MemberService.java
@@ -8,6 +8,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -17,7 +19,7 @@ public class MemberService {
     private final SecurityUtil securityUtil;
 
     @Transactional
-    public Member createmember(MemberCreateRequest request) {
+    public Member createMember(MemberCreateRequest request) {
         validateDuplicateEmail(request.email());
 
         Member member = Member.builder()
@@ -41,8 +43,10 @@ public class MemberService {
     }
 
     @Transactional
-    public Member updateNickname(long memberId, String nickname) {
-        Member member = findMemberById(memberId);
+    public Member updateNickname(String email, String nickname) {
+        Member member = memberRepository.findByEmail(email).orElseThrow(
+                () -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND)
+        );
         member.updateNickname(nickname);
         return member;
     }

--- a/backend/src/main/java/com/kongdak/domain/member/OAuthProvider.java
+++ b/backend/src/main/java/com/kongdak/domain/member/OAuthProvider.java
@@ -1,5 +1,17 @@
 package com.kongdak.domain.member;
 
+import com.kongdak.global.exception.BusinessException;
+import com.kongdak.global.exception.ErrorCode;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+
 public enum OAuthProvider {
-    KAKAO, GOOGLE
+    KAKAO, GOOGLE;
+
+    public static OAuthProvider from(String registrationId) {
+        return switch (registrationId.toLowerCase()) {
+            case "kakao" -> KAKAO;
+            case "google" -> GOOGLE;
+            default -> throw new BusinessException(ErrorCode.INVALID_PROVIDER);
+        };
+    }
 }

--- a/backend/src/main/java/com/kongdak/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/kongdak/global/exception/ErrorCode.java
@@ -11,6 +11,9 @@ public enum ErrorCode {
     INVALID_NICKNAME_LENGTH(400, "M004", "닉네임은 2자 이상 20자 이하여야 합니다"),
     INACTIVE_MEMBER(404, "M005", "비활성화된 회원입니다"),
 
+    // OAUTH2.0 관련 예외
+    INVALID_PROVIDER(400, "O001", "옳지 않은 PROVIDER 입니다."),
+
     // Couple 관련 예외
     COUPLE_NOT_FOUND(404, "C001", "커플을 찾을 수 없습니다"),
     MEMBER_ALREADY_COUPLED(400, "C002", "이미 커플 관계가 있는 회원입니다"),

--- a/backend/src/main/java/com/kongdak/global/security/jwt/CustomOAuth2UserService.java
+++ b/backend/src/main/java/com/kongdak/global/security/jwt/CustomOAuth2UserService.java
@@ -1,7 +1,10 @@
 package com.kongdak.global.security.jwt;
 
+import com.kongdak.controller.dto.request.MemberCreateRequest;
 import com.kongdak.domain.member.Member;
 import com.kongdak.domain.member.MemberRepository;
+import com.kongdak.domain.member.MemberService;
+import com.kongdak.domain.member.OAuthProvider;
 import com.kongdak.global.exception.BusinessException;
 import com.kongdak.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -14,11 +17,13 @@ import org.springframework.stereotype.Service;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     private final MemberRepository memberRepository;
+    private final MemberService memberService;
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
@@ -29,6 +34,18 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
         Map<String, Object> attributes = oauth2User.getAttributes();
         String email = extractEmail(registrationId, attributes);
+
+        // UUID로 임시 닉네임 생성
+        String tempNickname = "User" + UUID.randomUUID().toString().substring(0, 8);
+
+        // 회원가입 처리
+        Member member = memberRepository.findByEmail(email)
+                .orElseGet(() -> memberService.createMember(new MemberCreateRequest(email, tempNickname, OAuthProvider.from(registrationId))));
+
+        // 멤버가 비활성 상태인 경우 예외 처리
+        if (!member.isActive()) {
+            throw new OAuth2AuthenticationException("Inactive member");
+        }
 
         return new CustomOAuth2User(
                 oauth2User.getAuthorities(),

--- a/backend/src/main/java/com/kongdak/global/security/jwt/JwtTokenProvider.java
+++ b/backend/src/main/java/com/kongdak/global/security/jwt/JwtTokenProvider.java
@@ -17,6 +17,7 @@ import java.security.Key;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -46,8 +47,14 @@ public class JwtTokenProvider {
         Date now = new Date();
         Date validity = new Date(now.getTime() + accessTokenValidityInMilliseconds);
 
+        // attributes 확인을 위한 로그
+        log.info("OAuth2User attributes: {}", oAuth2User.getAttributes());
+
+        // 카카오 계정의 이메일 정보 가져오기
+        String email = ((Map<String, Object>) oAuth2User.getAttribute("kakao_account")).get("email").toString();
+
         return Jwts.builder()
-                .setSubject(oAuth2User.getAttribute("email"))
+                .setSubject(email)
                 .claim("id", oAuth2User.getAttribute("id"))
                 .claim("auth", oAuth2User.getAuthorities().stream()
                         .map(GrantedAuthority::getAuthority)
@@ -74,6 +81,11 @@ public class JwtTokenProvider {
     // 토큰에서 Authentication 객체 추출
     public Authentication getAuthentication(String token) {
         Claims claims = parseClaims(token);
+
+        log.info("Token claims: {}", claims);
+        log.info("id claim value: {}", claims.get("id"));
+        log.info("subject value: {}", claims.getSubject());
+        log.info("auth claim value: {}", claims.get("auth"));
 
         Collection<? extends GrantedAuthority> authorities =
                 Arrays.stream(claims.get("auth").toString().split(","))


### PR DESCRIPTION
- 로그인 시 회원가입 확인 여부 확인 후 처리하도록 함
- email 확인하여 닉네임 업데이트
- JwtTokenProvider 에 로깅 추가
- 카카오 계정의 이메일 정보 가져와서 Jwt 빌드함