### PR TITLE
커플 관련 테스트(Swagger)

### DIFF
--- a/backend/src/main/java/com/kongdak/controller/CoupleController.java
+++ b/backend/src/main/java/com/kongdak/controller/CoupleController.java
@@ -2,7 +2,6 @@ package com.kongdak.controller;
 
 import com.kongdak.controller.dto.request.ConnectCodeRequest;
 import com.kongdak.controller.dto.request.CoupleConnectRequest;
-import com.kongdak.controller.dto.request.CoupleMatchRequest;
 import com.kongdak.controller.dto.response.CoupleMatchCodeResponse;
 import com.kongdak.controller.dto.response.CoupleResponse;
 import com.kongdak.domain.couple.CoupleService;
@@ -18,10 +17,12 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
+@Slf4j
 @RequestMapping("/couples")
 @RequiredArgsConstructor
 @Tag(name = "커플", description = "커플 관련 API")
@@ -33,7 +34,7 @@ public class CoupleController {
     @Operation(summary = "연결 코드 조회", description = "현재 사용자의 연결 코드를 조회합니다.")
     public BaseResponse<CoupleMatchCodeResponse> getConnectCode(
             @AuthenticationPrincipal CustomUserDetails userDetails) {
-        String code = coupleService.getConnectCode(Long.parseLong(userDetails.getUsername()));
+        String code = coupleService.getConnectCode(userDetails.getId());
         return BaseResponse.ok(new CoupleMatchCodeResponse(code));
     }
 
@@ -43,7 +44,7 @@ public class CoupleController {
             @RequestBody @Valid ConnectCodeRequest request,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
         coupleService.requestMatch(
-                Long.parseLong(userDetails.getUsername()),
+                userDetails.getId(),
                 request.code()
         );
         return BaseResponse.ok();
@@ -52,18 +53,24 @@ public class CoupleController {
     @PostMapping("/match/{requestId}/accept")
     @Operation(summary = "매칭 수락", description = "커플 매칭 요청을 수락합니다.")
     public BaseResponse<Void> acceptMatch(
-            @PathVariable String requestId,
+            @Parameter(description = "매칭 요청 ID", required = true)
+            @PathVariable("requestId") String requestId,
+            @Parameter(description = "인증된 사용자 ID", hidden = true)
             @AuthenticationPrincipal CustomUserDetails userDetails) {
-        coupleService.acceptMatch(requestId, Long.parseLong(userDetails.getUsername()));
+        coupleService.acceptMatch(requestId, userDetails.getId());
+
         return BaseResponse.ok();
     }
 
     @PostMapping("/match/{requestId}/reject")
     @Operation(summary = "매칭 거절", description = "커플 매칭 요청을 거절합니다.")
     public BaseResponse<Void> rejectMatch(
-            @PathVariable String requestId,
+            @Parameter(description = "매칭 요청 ID", required = true)
+            @PathVariable("requestId") String requestId,
+            @Parameter(description = "인증된 사용자 ID", hidden = true)
             @AuthenticationPrincipal CustomUserDetails userDetails) {
-        coupleService.rejectMatch(requestId, Long.parseLong(userDetails.getUsername()));
+        log.info("Received requestId: {}", requestId);  // 로그 추가
+        coupleService.rejectMatch(requestId, userDetails.getId());
         return BaseResponse.ok();
     }
 
@@ -84,12 +91,13 @@ public class CoupleController {
             )
     })
     @PostMapping
-    public BaseResponse<CoupleResponse> connect(@RequestBody @Valid
-                                                @Parameter(description = "커플 연결 요청") CoupleConnectRequest request,
-                                                @Parameter(description = "인증된 사용자 정보", hidden = true)
-                                                @AuthenticationPrincipal CustomUserDetails userDetails) {
+    public BaseResponse<CoupleResponse> connect(
+            @RequestBody @Valid
+            @Parameter(description = "커플 연결 요청") CoupleConnectRequest request,
+            @Parameter(description = "인증된 사용자 정보", hidden = true)
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
         CoupleResponse response = coupleService.connect(
-                Long.parseLong(userDetails.getUsername()),
+                userDetails.getId(),
                 request.partnerId(),
                 request.anniversaryDate()
         );
@@ -113,11 +121,11 @@ public class CoupleController {
     })
     @PatchMapping("/{coupleId}/disconnect")
     public BaseResponse<Void> disconnect(
-                                            @Parameter(description = "커플 ID", required = true)
-                                            @PathVariable Long coupleId,
-                                           @Parameter(description = "인증된 사용자 정보", hidden = true)
-                                           @AuthenticationPrincipal CustomUserDetails userDetails) {
-        coupleService.disconnect(coupleId, Long.parseLong(userDetails.getUsername()));
+            @Parameter(description = "커플 ID", required = true)
+            @PathVariable("coupleId") Long coupleId,
+            @Parameter(description = "인증된 사용자 정보", hidden = true)
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        coupleService.disconnect(coupleId, userDetails.getId());
         return BaseResponse.ok();
     }
 
@@ -137,9 +145,12 @@ public class CoupleController {
             )
     })
     @PatchMapping("/{coupleId}/restore")
-    public BaseResponse<Void> restore(@PathVariable Long coupleId,
-                                        @AuthenticationPrincipal CustomUserDetails userDetails) {
-        coupleService.restore(coupleId, Long.parseLong(userDetails.getUsername()));
+    public BaseResponse<Void> restore(
+            @Parameter(description = "커플 ID", required = true)
+            @PathVariable("coupleId") Long coupleId,
+            @Parameter(description = "인증된 사용자 정보", hidden = true)
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        coupleService.restore(coupleId, userDetails.getId());
         return BaseResponse.ok();
     }
 }

--- a/backend/src/main/java/com/kongdak/domain/calendar/Calendar.java
+++ b/backend/src/main/java/com/kongdak/domain/calendar/Calendar.java
@@ -21,7 +21,7 @@ public class Calendar extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "couple_id", nullable = false)
     private Couple couple;
 

--- a/backend/src/main/java/com/kongdak/domain/couple/Couple.java
+++ b/backend/src/main/java/com/kongdak/domain/couple/Couple.java
@@ -44,6 +44,8 @@ public class Couple extends BaseTimeEntity {
     public Couple(Member member1, Member member2, LocalDateTime anniversaryDate) {
         this.member1 = member1;
         this.member2 = member2;
+        this.connectedAt = LocalDateTime.now();
+        this.isConnected = true;
         this.anniversaryDate = anniversaryDate;
     }
 

--- a/backend/src/main/java/com/kongdak/domain/couple/CoupleMatchRedisRepository.java
+++ b/backend/src/main/java/com/kongdak/domain/couple/CoupleMatchRedisRepository.java
@@ -2,6 +2,7 @@ package com.kongdak.domain.couple;
 
 import com.kongdak.controller.dto.request.CoupleMatchRequest;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
 
@@ -10,6 +11,7 @@ import java.util.Optional;
 import java.util.Random;
 
 @Repository
+@Slf4j
 @RequiredArgsConstructor
 public class CoupleMatchRedisRepository {
     private static final String CONNECT_CODE_PREFIX = "couple:connect:code:";
@@ -57,11 +59,15 @@ public class CoupleMatchRedisRepository {
     // 매칭 요청 조회
     public Optional<CoupleMatchRequest> findCoupleMatchRequest(String requestId) {
         String value = redisTemplate.opsForValue().get(MATCH_REQUEST_PREFIX + requestId);
+        log.info("[CoupleMatchRedisRepository-findCoupleMatchRequest] - MATCH_REQUEST_PREFIX + requestId : {}", MATCH_REQUEST_PREFIX + requestId);
+        log.info("[CoupleMatchRedisRepository-findCoupleMatchRequest] - value : {}", value);
         if (value == null) {
             return Optional.empty();
         }
 
         String[] parts = value.split(":");
+        log.info("[CoupleMatchRedisRepository-findCoupleMatchRequest] - parts[0] : {}", parts[0]);
+        log.info("[CoupleMatchRedisRepository-findCoupleMatchRequest] - parts[1] : {}", parts[1]);
         return Optional.of(new CoupleMatchRequest(
                 Long.parseLong(parts[0]),
                 Long.parseLong(parts[1])

--- a/backend/src/main/java/com/kongdak/domain/couple/CoupleService.java
+++ b/backend/src/main/java/com/kongdak/domain/couple/CoupleService.java
@@ -12,6 +12,7 @@ import com.kongdak.domain.notification.SseEmitterService;
 import com.kongdak.global.exception.BusinessException;
 import com.kongdak.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,6 +20,7 @@ import java.time.LocalDateTime;
 import java.util.Random;
 
 @Service
+@Slf4j
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class CoupleService {
@@ -58,12 +60,15 @@ public class CoupleService {
     // 매칭 수락
     @Transactional
     public void acceptMatch(String requestId, Long memberId) {
+        log.info("[CoupleService - acceptMatch] - requestId : {} , memberId : {}", requestId, memberId);
         CoupleMatchRequest request = coupleMatchRedisRepository.findCoupleMatchRequest(requestId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.COUPLE_MATCH_REQUEST_NOT_FOUND));
 
         if (!request.targetId().equals(memberId)) {
             throw new BusinessException(ErrorCode.CANNOT_MATCH_TO_OWN);
         }
+
+        log.info("[CoupleService - acceptMatch] - request.requesterId : {} , memberId : {}", request.requesterId(), memberId);
         // 커플 연결 처리
         connect(request.requesterId(), memberId, LocalDateTime.now());
 
@@ -102,16 +107,20 @@ public class CoupleService {
 
     @Transactional
     public CoupleResponse connect(Long memberId, Long partnerId, LocalDateTime anniversaryDate) {
+
         Member member = memberService.findMemberById(memberId);
         Member partner = memberService.findMemberById(partnerId);
 
         validateConnection(member, partner);
 
-        Couple couple = Couple.builder()
-                .member1(member)
-                .member2(partner)
-                .anniversaryDate(anniversaryDate)
-                .build();
+        // 먼저 Couple을 저장
+        Couple couple = coupleRepository.save(
+                Couple.builder()
+                        .member1(member)
+                        .member2(partner)
+                        .anniversaryDate(anniversaryDate)
+                        .build()
+        );
 
         // Calendar도 생성되어야 한다.
         Calendar calendar = Calendar.builder()

--- a/backend/src/main/java/com/kongdak/global/security/jwt/CustomOAuth2User.java
+++ b/backend/src/main/java/com/kongdak/global/security/jwt/CustomOAuth2User.java
@@ -1,26 +1,19 @@
 package com.kongdak.global.security.jwt;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 
 import java.util.Collection;
 import java.util.Map;
 
+@RequiredArgsConstructor
 public class CustomOAuth2User implements OAuth2User {
+    private final Long memberId;
     private final Collection<? extends GrantedAuthority> authorities;
     private final Map<String, Object> attributes;
     private final String provider;
     private final String email;
-
-    public CustomOAuth2User(Collection<? extends GrantedAuthority> authorities,
-                            Map<String, Object> attributes,
-                            String provider,
-                            String email) {
-        this.authorities = authorities;
-        this.attributes = attributes;
-        this.provider = provider;
-        this.email = email;
-    }
 
     @Override
     public Map<String, Object> getAttributes() {
@@ -43,5 +36,9 @@ public class CustomOAuth2User implements OAuth2User {
 
     public String getEmail() {
         return email;
+    }
+
+    public Long getId() {
+        return memberId;
     }
 }

--- a/backend/src/main/java/com/kongdak/global/security/jwt/CustomOAuth2UserService.java
+++ b/backend/src/main/java/com/kongdak/global/security/jwt/CustomOAuth2UserService.java
@@ -48,6 +48,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         }
 
         return new CustomOAuth2User(
+                member.getId(),
                 oauth2User.getAuthorities(),
                 attributes,
                 registrationId,
@@ -81,6 +82,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         );
 
         return new CustomOAuth2User(
+                member.getId(),
                 Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")),
                 attributes,
                 member.getOauthProvider().toString(),

--- a/backend/src/main/java/com/kongdak/global/security/jwt/JwtTokenProvider.java
+++ b/backend/src/main/java/com/kongdak/global/security/jwt/JwtTokenProvider.java
@@ -51,17 +51,34 @@ public class JwtTokenProvider {
         log.info("OAuth2User attributes: {}", oAuth2User.getAttributes());
         String email;
         Long id;
-
-        Map<String, Object> attributes = oAuth2User.getAttributes();
-        if (attributes.containsKey("kakao_account")) {
-            // 카카오 로그인
-            email = ((Map<String, Object>) attributes.get("kakao_account")).get("email").toString();
-            id = Long.valueOf(attributes.get("id").toString());
+        if (oAuth2User instanceof CustomOAuth2User) {
+            id = ((CustomOAuth2User) oAuth2User).getId();
+            log.info("JwtTokenProvider에서 id : {}", id);
+            email = ((CustomOAuth2User) oAuth2User).getEmail();
         } else {
-            // 구글 로그인
-            email = attributes.get("email").toString();
-            id = Long.valueOf(attributes.get("sub").toString()); // Google uses 'sub' as unique identifier
+            // 기본 OAuth2User의 경우 attributes에서 id를 추출
+            Map<String, Object> attributes = oAuth2User.getAttributes();
+            if (attributes.containsKey("kakao_account")) {
+                email = ((Map<String, Object>) attributes.get("kakao_account")).get("email").toString();
+                id = Long.valueOf(attributes.get("id").toString());
+                log.info("JwtTokenProvider에서 카카오로 갔음. id : {}", id);
+            } else {
+                email = attributes.get("email").toString();
+                id = Long.valueOf(attributes.get("sub").toString());
+            }
         }
+
+
+//        Map<String, Object> attributes = oAuth2User.getAttributes();
+//        if (attributes.containsKey("kakao_account")) {
+//            // 카카오 로그인
+//            email = ((Map<String, Object>) attributes.get("kakao_account")).get("email").toString();
+//            id = Long.valueOf(attributes.get("id").toString());
+//        } else {
+//            // 구글 로그인
+//            email = attributes.get("email").toString();
+//            id = Long.valueOf(attributes.get("sub").toString()); // Google uses 'sub' as unique identifier
+//        }
 
         return Jwts.builder()
                 .setSubject(email)


### PR DESCRIPTION
# PR Description

## 1. Calendar 엔티티 수정
- `Calendar` 엔티티에 `cascade` 옵션 추가
- `Couple` 엔티티와의 연관관계에 `CascadeType.ALL` 적용

## 2. Couple 엔티티 Builder 개선
- `Couple` 생성자에 필수 필드 추가:
  - `connectedAt`: 현재 시간으로 초기화
  - `isConnected`: `true`로 초기화

## 3. CustomOAuth2User 클래스 수정
- MariaDB에서 생성된 `memberId`를 사용하도록 변경
- 불필요한 생성자 제거
- `getId()` 메서드 추가
- `JwtTokenProvider`에서 `CustomOAuth2User` 타입 체크 로직 개선

## 4. Couple 관련 로직 개선
### CoupleController
- Parameter 설명 개선
- 로그 메시지 추가
- `userDetails`에서 ID 추출 방식 개선

### CoupleService
- 로그 추가
- `Couple` 저장 로직 개선

### CoupleMatchRedisRepository
- 디버깅을 위한 로그 추가
