### PR TITLE
전반적인 응답 형식 표준화 및 Member-Couple 관계 개선

### DIFF
--- a/backend/src/main/java/com/kongdak/controller/CalendarController.java
+++ b/backend/src/main/java/com/kongdak/controller/CalendarController.java
@@ -2,6 +2,7 @@ package com.kongdak.controller;
 
 import com.kongdak.controller.dto.request.ScheduleCreateRequest;
 import com.kongdak.controller.dto.response.MonthlyScheduleResponse;
+import com.kongdak.controller.dto.response.ScheduleDeleteResponse;
 import com.kongdak.controller.dto.response.ScheduleDetailResponse;
 import com.kongdak.controller.dto.response.ScheduleResponse;
 import com.kongdak.domain.calendar.CalendarService;
@@ -140,10 +141,9 @@ public class CalendarController {
             )
     })
     @DeleteMapping("/{calendarId}/schedules/{scheduleId}")
-    public BaseResponse<Void> deleteSchedule(
+    public BaseResponse<ScheduleDeleteResponse> deleteSchedule(
             @PathVariable Long calendarId,
             @PathVariable Long scheduleId) {
-        calendarService.deleteSchedule(calendarId, scheduleId);
-        return BaseResponse.ok();
+        return BaseResponse.ok(calendarService.deleteSchedule(calendarId, scheduleId));
     }
 }

--- a/backend/src/main/java/com/kongdak/controller/CoupleController.java
+++ b/backend/src/main/java/com/kongdak/controller/CoupleController.java
@@ -2,8 +2,7 @@ package com.kongdak.controller;
 
 import com.kongdak.controller.dto.request.ConnectCodeRequest;
 import com.kongdak.controller.dto.request.CoupleConnectRequest;
-import com.kongdak.controller.dto.response.CoupleMatchCodeResponse;
-import com.kongdak.controller.dto.response.CoupleResponse;
+import com.kongdak.controller.dto.response.*;
 import com.kongdak.domain.couple.CoupleService;
 import com.kongdak.global.exception.ErrorResponse;
 import com.kongdak.global.response.BaseResponse;
@@ -40,38 +39,35 @@ public class CoupleController {
 
     @PostMapping("/match")
     @Operation(summary = "커플 매칭 요청", description = "상대방의 연결 코드로 커플 매칭을 요청합니다.")
-    public BaseResponse<Void> requestMatch(
+    public BaseResponse<MatchRequestResponse> requestMatch(
             @RequestBody @Valid ConnectCodeRequest request,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
-        coupleService.requestMatch(
+        return BaseResponse.ok(coupleService.requestMatch(
                 userDetails.getId(),
                 request.code()
-        );
-        return BaseResponse.ok();
+        ));
     }
 
     @PostMapping("/match/{requestId}/accept")
     @Operation(summary = "매칭 수락", description = "커플 매칭 요청을 수락합니다.")
-    public BaseResponse<Void> acceptMatch(
+    public BaseResponse<MatchAcceptResponse> acceptMatch(
             @Parameter(description = "매칭 요청 ID", required = true)
             @PathVariable("requestId") String requestId,
             @Parameter(description = "인증된 사용자 ID", hidden = true)
             @AuthenticationPrincipal CustomUserDetails userDetails) {
-        coupleService.acceptMatch(requestId, userDetails.getId());
-
-        return BaseResponse.ok();
+        return BaseResponse.ok(coupleService.acceptMatch(requestId, userDetails.getId()));
     }
 
     @PostMapping("/match/{requestId}/reject")
     @Operation(summary = "매칭 거절", description = "커플 매칭 요청을 거절합니다.")
-    public BaseResponse<Void> rejectMatch(
+    public BaseResponse<MatchRejectResponse> rejectMatch(
             @Parameter(description = "매칭 요청 ID", required = true)
             @PathVariable("requestId") String requestId,
             @Parameter(description = "인증된 사용자 ID", hidden = true)
             @AuthenticationPrincipal CustomUserDetails userDetails) {
         log.info("Received requestId: {}", requestId);  // 로그 추가
-        coupleService.rejectMatch(requestId, userDetails.getId());
-        return BaseResponse.ok();
+
+        return BaseResponse.ok(coupleService.rejectMatch(requestId, userDetails.getId()));
     }
 
     @Operation(
@@ -120,13 +116,12 @@ public class CoupleController {
             )
     })
     @PatchMapping("/{coupleId}/disconnect")
-    public BaseResponse<Void> disconnect(
+    public BaseResponse<CoupleDisconnectResponse> disconnect(
             @Parameter(description = "커플 ID", required = true)
             @PathVariable("coupleId") Long coupleId,
             @Parameter(description = "인증된 사용자 정보", hidden = true)
             @AuthenticationPrincipal CustomUserDetails userDetails) {
-        coupleService.disconnect(coupleId, userDetails.getId());
-        return BaseResponse.ok();
+        return BaseResponse.ok(coupleService.disconnect(coupleId, userDetails.getId()));
     }
 
     @Operation(
@@ -145,12 +140,12 @@ public class CoupleController {
             )
     })
     @PatchMapping("/{coupleId}/restore")
-    public BaseResponse<Void> restore(
+    public BaseResponse<CoupleRestoreResponse> restore(
             @Parameter(description = "커플 ID", required = true)
             @PathVariable("coupleId") Long coupleId,
             @Parameter(description = "인증된 사용자 정보", hidden = true)
             @AuthenticationPrincipal CustomUserDetails userDetails) {
-        coupleService.restore(coupleId, userDetails.getId());
-        return BaseResponse.ok();
+
+        return BaseResponse.ok(coupleService.restore(coupleId, userDetails.getId()));
     }
 }

--- a/backend/src/main/java/com/kongdak/controller/DailyQuestionController.java
+++ b/backend/src/main/java/com/kongdak/controller/DailyQuestionController.java
@@ -32,8 +32,11 @@ public class DailyQuestionController {
     @Operation(summary = "오늘의 질문 조회", description = "오늘의 데일리 질문을 조회합니다.")
     @ApiResponse(responseCode = "200", description = "조회 성공",
             content = @Content(schema = @Schema(implementation = BaseResponse.class)))
-    public BaseResponse<DailyQuestionResponse> getDailyQuestion() {
-        return BaseResponse.ok(dailyQuestionService.getDailyQuestion());
+    public BaseResponse<DailyQuestionResponse> getDailyQuestion(
+            @Parameter(description = "인증된 사용자 ID", hidden = true)
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        return BaseResponse.ok(dailyQuestionService.getDailyQuestion(userDetails.getId()));
     }
 
     @Operation(summary = "답변 목록 조회", description = "특정 질문에 대한 답변 목록을 조회합니다.")
@@ -44,7 +47,7 @@ public class DailyQuestionController {
             @Parameter(description = "인증된 사용자 ID", hidden = true)
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @Parameter(description = "질문 ID", required = true)
-            @PathVariable Long questionId) {
+            @PathVariable("questionId") Long questionId) {
         return BaseResponse.ok(
                 dailyQuestionService.getAnswers(userDetails.getId(), questionId)
         );
@@ -58,7 +61,7 @@ public class DailyQuestionController {
             @Parameter(description = "인증된 사용자 ID", hidden = true)
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @Parameter(description = "질문 ID", required = true)
-            @PathVariable Long questionId,
+            @PathVariable("questionId") Long questionId,
             @Parameter(description = "답변 내용")
             @RequestBody @Valid DailyAnswerRequest request) {
         return BaseResponse.created(dailyQuestionService.createAnswer(userDetails.getId(), questionId, request));
@@ -72,9 +75,9 @@ public class DailyQuestionController {
             @Parameter(description = "인증된 사용자 ID", hidden = true)
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @Parameter(description = "질문 ID", required = true)
-            @PathVariable Long questionId,
+            @PathVariable("questionId") Long questionId,
             @Parameter(description = "답변 ID", required = true)
-            @PathVariable Long answerId,
+            @PathVariable("answerId") Long answerId,
             @Parameter(description = "이모지 정보")
             @RequestBody @Valid EmojiRequest request) {
         dailyQuestionService.addEmoji(userDetails.getId(), answerId, request);
@@ -89,7 +92,7 @@ public class DailyQuestionController {
             @Parameter(description = "인증된 사용자 ID", hidden = true)
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @Parameter(description = "질문 ID", required = true)
-            @PathVariable Long questionId,
+            @PathVariable("questionId") Long questionId,
             @Parameter(description = "댓글 내용")
             @RequestBody @Valid ReplyRequest request) {
         dailyQuestionService.addReply(userDetails.getId(), questionId, request);
@@ -104,7 +107,7 @@ public class DailyQuestionController {
             @Parameter(description = "인증된 사용자 ID", hidden = true)
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @Parameter(description = "질문 ID", required = true)
-            @PathVariable Long questionId,
+            @PathVariable("questionId") Long questionId,
             @Parameter(description = "댓글 ID", required = true)
             @PathVariable Long replyId) {
         dailyQuestionService.deleteReply(userDetails.getId(), questionId, replyId);

--- a/backend/src/main/java/com/kongdak/controller/DailyQuestionController.java
+++ b/backend/src/main/java/com/kongdak/controller/DailyQuestionController.java
@@ -3,8 +3,7 @@ package com.kongdak.controller;
 import com.kongdak.controller.dto.request.DailyAnswerRequest;
 import com.kongdak.controller.dto.request.EmojiRequest;
 import com.kongdak.controller.dto.request.ReplyRequest;
-import com.kongdak.controller.dto.response.DailyAnswerResponse;
-import com.kongdak.controller.dto.response.DailyQuestionResponse;
+import com.kongdak.controller.dto.response.*;
 import com.kongdak.domain.dailyquestion.DailyQuestionService;
 import com.kongdak.global.response.BaseResponse;
 import com.kongdak.global.security.jwt.CustomUserDetails;
@@ -71,7 +70,7 @@ public class DailyQuestionController {
     @Operation(summary = "답변에 이모지 추가", description = "답변에 이모지 반응을 추가합니다.")
     @ApiResponse(responseCode = "200", description = "이모지 추가 성공",
             content = @Content(schema = @Schema(implementation = BaseResponse.class)))
-    public BaseResponse<Void> addEmoji(
+    public BaseResponse<AnswerEmojiResponse> addEmoji(
             @Parameter(description = "인증된 사용자 ID", hidden = true)
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @Parameter(description = "질문 ID", required = true)
@@ -80,37 +79,37 @@ public class DailyQuestionController {
             @PathVariable("answerId") Long answerId,
             @Parameter(description = "이모지 정보")
             @RequestBody @Valid EmojiRequest request) {
-        dailyQuestionService.addEmoji(userDetails.getId(), answerId, request);
-        return BaseResponse.ok();
+
+        return BaseResponse.ok(dailyQuestionService.addEmoji(userDetails.getId(), answerId, request));
     }
 
     @Operation(summary = "댓글 작성", description = "답변에 댓글을 작성합니다.")
     @ApiResponse(responseCode = "200", description = "댓글 작성 성공",
             content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @PostMapping("/{questionId}/replies")
-    public BaseResponse<Void> addReply(
+    public BaseResponse<ReplyCreateResponse> addReply(
             @Parameter(description = "인증된 사용자 ID", hidden = true)
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @Parameter(description = "질문 ID", required = true)
             @PathVariable("questionId") Long questionId,
             @Parameter(description = "댓글 내용")
             @RequestBody @Valid ReplyRequest request) {
-        dailyQuestionService.addReply(userDetails.getId(), questionId, request);
-        return BaseResponse.created();
+
+        return BaseResponse.created(dailyQuestionService.addReply(userDetails.getId(), questionId, request));
     }
 
     @Operation(summary = "댓글 삭제", description = "작성한 댓글을 삭제합니다.")
     @ApiResponse(responseCode = "200", description = "댓글 삭제 성공",
             content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @DeleteMapping("/{questionId}/replies/{replyId}")
-    public BaseResponse<Void> deleteReply(
+    public BaseResponse<ReplyDeleteResponse> deleteReply(
             @Parameter(description = "인증된 사용자 ID", hidden = true)
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @Parameter(description = "질문 ID", required = true)
             @PathVariable("questionId") Long questionId,
             @Parameter(description = "댓글 ID", required = true)
             @PathVariable Long replyId) {
-        dailyQuestionService.deleteReply(userDetails.getId(), questionId, replyId);
-        return BaseResponse.ok();
+
+        return BaseResponse.ok(dailyQuestionService.deleteReply(userDetails.getId(), questionId, replyId));
     }
 }

--- a/backend/src/main/java/com/kongdak/controller/DiaryController.java
+++ b/backend/src/main/java/com/kongdak/controller/DiaryController.java
@@ -2,9 +2,7 @@ package com.kongdak.controller;
 
 import com.kongdak.controller.dto.request.CreateDiaryRequest;
 import com.kongdak.controller.dto.request.UpdateDiaryRequest;
-import com.kongdak.controller.dto.response.DiaryCreateResponse;
-import com.kongdak.controller.dto.response.DiaryDetailResponse;
-import com.kongdak.controller.dto.response.SearchDiaryResponse;
+import com.kongdak.controller.dto.response.*;
 import com.kongdak.domain.diary.DiaryService;
 import com.kongdak.global.response.BaseResponse;
 import com.kongdak.global.security.jwt.CustomUserDetails;
@@ -75,7 +73,7 @@ public class DiaryController {
     @ApiResponse(responseCode = "200", description = "수정 성공",
             content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @PutMapping("/{diaryId}")
-    public BaseResponse<Void> updateDiary(
+    public BaseResponse<DiaryUpdateResponse> updateDiary(
             @Parameter(description = "인증된 사용자 ID", hidden = true)
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @Parameter(description = "다이어리 ID", required = true)
@@ -83,22 +81,22 @@ public class DiaryController {
             @Parameter(description = "다이어리 수정 정보")
             @RequestBody @Valid UpdateDiaryRequest request
     ) {
-        diaryService.updateDiary(userDetails.getId(), diaryId, request);
-        return BaseResponse.ok();
+
+        return BaseResponse.ok(diaryService.updateDiary(userDetails.getId(), diaryId, request));
     }
 
     @Operation(summary = "다이어리 삭제", description = "작성된 다이어리를 삭제합니다.")
     @ApiResponse(responseCode = "200", description = "삭제 성공",
             content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @DeleteMapping("/{diaryId}")
-    public BaseResponse<Void> deleteDiary(
+    public BaseResponse<DiaryDeleteResponse> deleteDiary(
             @Parameter(description = "인증된 사용자 ID", hidden = true)
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @Parameter(description = "다이어리 ID", required = true)
             @PathVariable("diaryId") Long diaryId
     ) {
-        diaryService.deleteDiary(userDetails.getId(), diaryId);
-        return BaseResponse.ok();
+
+        return BaseResponse.ok(diaryService.deleteDiary(userDetails.getId(), diaryId));
     }
 
     @Operation(summary = "다이어리 락 획득", description = "다이어리 편집을 위한 락을 획득합니다.")

--- a/backend/src/main/java/com/kongdak/controller/DiaryController.java
+++ b/backend/src/main/java/com/kongdak/controller/DiaryController.java
@@ -52,7 +52,7 @@ public class DiaryController {
             @Parameter(description = "인증된 사용자 ID", hidden = true)
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @Parameter(description = "다이어리 ID", required = true)
-            @PathVariable Long diaryId
+            @PathVariable("diaryId") Long diaryId
     ) {
         return BaseResponse.ok(diaryService.getDiary(userDetails.getId(), diaryId));
     }
@@ -79,7 +79,7 @@ public class DiaryController {
             @Parameter(description = "인증된 사용자 ID", hidden = true)
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @Parameter(description = "다이어리 ID", required = true)
-            @PathVariable Long diaryId,
+            @PathVariable("diaryId") Long diaryId,
             @Parameter(description = "다이어리 수정 정보")
             @RequestBody @Valid UpdateDiaryRequest request
     ) {
@@ -95,7 +95,7 @@ public class DiaryController {
             @Parameter(description = "인증된 사용자 ID", hidden = true)
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @Parameter(description = "다이어리 ID", required = true)
-            @PathVariable Long diaryId
+            @PathVariable("diaryId") Long diaryId
     ) {
         diaryService.deleteDiary(userDetails.getId(), diaryId);
         return BaseResponse.ok();
@@ -109,7 +109,7 @@ public class DiaryController {
             @Parameter(description = "인증된 사용자 ID", hidden = true)
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @Parameter(description = "다이어리 ID", required = true)
-            @PathVariable Long diaryId
+            @PathVariable("diaryId") Long diaryId
     ) {
         return BaseResponse.ok(diaryService.acquireLock(diaryId, userDetails.getId()));
     }
@@ -122,7 +122,7 @@ public class DiaryController {
             @Parameter(description = "인증된 사용자 ID", hidden = true)
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @Parameter(description = "다이어리 ID", required = true)
-            @PathVariable Long diaryId
+            @PathVariable("diaryId") Long diaryId
     ) {
         diaryService.releaseLock(diaryId, userDetails.getId());
         return BaseResponse.ok();

--- a/backend/src/main/java/com/kongdak/controller/MemberController.java
+++ b/backend/src/main/java/com/kongdak/controller/MemberController.java
@@ -1,8 +1,8 @@
 package com.kongdak.controller;
 
 import com.kongdak.controller.dto.request.UpdateNicknameRequest;
+import com.kongdak.controller.dto.response.DeactivateResponse;
 import com.kongdak.controller.dto.response.MemberResponse;
-import com.kongdak.domain.member.Member;
 import com.kongdak.domain.member.MemberService;
 import com.kongdak.global.response.BaseResponse;
 import com.kongdak.global.security.jwt.CustomUserDetails;
@@ -32,8 +32,7 @@ public class MemberController {
     public BaseResponse<MemberResponse> getMemberInfo(
             @Parameter(description = "인증된 사용자 정보", hidden = true)
             @AuthenticationPrincipal CustomUserDetails userDetails) {
-        Member member = memberService.findByEmail(userDetails.getEmail());
-        return BaseResponse.ok(MemberResponse.from(member));
+        return BaseResponse.ok(memberService.getMemberInfo(userDetails.getEmail()));
     }
 
     @Operation(summary = "닉네임 수정", description = "회원의 닉네임을 수정합니다.")
@@ -45,21 +44,20 @@ public class MemberController {
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @Parameter(description = "변경할 닉네임 정보")
             @RequestBody @Valid UpdateNicknameRequest request) {
-        Member member = memberService.updateNickname(
+        return BaseResponse.ok(memberService.updateNickname(
                 userDetails.getUsername(),
                 request.nickname()
-        );
-        return BaseResponse.ok(MemberResponse.from(member));
+        ));
     }
 
     @Operation(summary = "회원 탈퇴", description = "회원 계정을 비활성화합니다.")
     @ApiResponse(responseCode = "200", description = "탈퇴 성공",
             content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @DeleteMapping
-    public BaseResponse<Void> deactivateMember(
+    public BaseResponse<DeactivateResponse> deactivateMember(
             @Parameter(description = "인증된 사용자 정보", hidden = true)
             @AuthenticationPrincipal CustomUserDetails userDetails) {
-        memberService.deactivateMember(userDetails.getUsername());
-        return BaseResponse.ok();
+
+        return BaseResponse.ok(memberService.deactivateMember(userDetails.getUsername()));
     }
 }

--- a/backend/src/main/java/com/kongdak/controller/dto/request/CreateDiaryRequest.java
+++ b/backend/src/main/java/com/kongdak/controller/dto/request/CreateDiaryRequest.java
@@ -15,18 +15,16 @@ public record CreateDiaryRequest(
         String content,
 
         @Schema(description = "감정 상태", example = "HAPPY", required = true)
-        @NotNull
         Emotion emotion,
 
         @Schema(description = "날씨", example = "SUNNY", required = true)
-        @NotNull
         Weather weather,
 
         @Schema(description = "다이어리 작성 날짜", example = "2024-01-10", required = true)
         @NotNull
         LocalDate diaryDate,
 
-        @Schema(description = "첨부된 사진 URL 목록", example = "['photo1.jpg', 'photo2.jpg']")
+        @Schema(description = "첨부된 사진 URL 목록", example = "[\"photo1.jpg\", \"photo2.jpg\"]")
         List<String> photoUrls,
 
         @Schema(description = "데코레이션 목록")

--- a/backend/src/main/java/com/kongdak/controller/dto/request/DecorationCreateRequest.java
+++ b/backend/src/main/java/com/kongdak/controller/dto/request/DecorationCreateRequest.java
@@ -17,6 +17,6 @@ public record DecorationCreateRequest(
         @Schema(description = "Y 좌표", example = "100")
         Integer positionY,
 
-        @Schema(description = "스타일 정보", example = "size: 2rem;")
+        @Schema(description = "스타일 정보", example = "{\"fontSize\": \"2rem\", \"color\": \"red\"}")
         String style
 ) {}

--- a/backend/src/main/java/com/kongdak/controller/dto/request/DecorationUpdateRequest.java
+++ b/backend/src/main/java/com/kongdak/controller/dto/request/DecorationUpdateRequest.java
@@ -20,6 +20,6 @@ public record DecorationUpdateRequest(
         @Schema(description = "Y 좌표", example = "100")
         Integer positionY,
 
-        @Schema(description = "스타일 정보", example = "size: 2rem;")
+        @Schema(description = "스타일 정보", example = "{\"fontSize\": \"2rem\", \"color\": \"red\"}")
         String style
 ) {}

--- a/backend/src/main/java/com/kongdak/controller/dto/request/UpdateDiaryRequest.java
+++ b/backend/src/main/java/com/kongdak/controller/dto/request/UpdateDiaryRequest.java
@@ -21,7 +21,7 @@ public record UpdateDiaryRequest(
         @NotNull
         Weather weather,
 
-        @Schema(description = "첨부된 사진 URL 목록", example = "['photo1.jpg', 'photo2.jpg']")
+        @Schema(description = "첨부된 사진 URL 목록", example = "[\"photo1.jpg\", \"photo2.jpg\"]")
         List<String> photoUrls,
 
         @Schema(description = "데코레이션 목록")

--- a/backend/src/main/java/com/kongdak/controller/dto/response/AnswerEmojiResponse.java
+++ b/backend/src/main/java/com/kongdak/controller/dto/response/AnswerEmojiResponse.java
@@ -1,0 +1,33 @@
+package com.kongdak.controller.dto.response;
+
+import com.kongdak.domain.dailyquestion.AnswerEmoji;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+@Schema(description = "답변 이모지 추가 응답")
+public record AnswerEmojiResponse(
+        @Schema(description = "이모지 ID", example = "1")
+        Long emojiId,
+
+        @Schema(description = "답변 ID", example = "1")
+        Long answerId,
+
+        @Schema(description = "이모지를 추가한 사용자 ID", example = "2")
+        Long memberId,
+
+        @Schema(description = "추가된 이모지", example = "👍")
+        String emoji,
+
+        @Schema(description = "이모지 추가 시간", example = "2024-01-19T18:30:00")
+        LocalDateTime createdAt
+) {
+    public static AnswerEmojiResponse from(AnswerEmoji answerEmoji) {
+        return new AnswerEmojiResponse(
+                answerEmoji.getId(),
+                answerEmoji.getAnswer().getId(),
+                answerEmoji.getMember().getId(),
+                answerEmoji.getEmoji(),
+                answerEmoji.getCreatedAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/kongdak/controller/dto/response/CoupleDisconnectResponse.java
+++ b/backend/src/main/java/com/kongdak/controller/dto/response/CoupleDisconnectResponse.java
@@ -1,0 +1,23 @@
+package com.kongdak.controller.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+@Schema(description = "커플 연결 해제 응답")
+public record CoupleDisconnectResponse(
+        @Schema(description = "커플 ID", example = "1")
+        Long coupleId,
+
+        @Schema(description = "연결 해제 요청자 ID", example = "2")
+        Long requesterId,
+
+        @Schema(description = "연결 해제 시간", example = "2024-01-19T18:30:00")
+        LocalDateTime disconnectedAt,
+
+        @Schema(description = "연결 지속 기간(일)", example = "100")
+        Long durationDays
+) {
+    public static CoupleDisconnectResponse of(Long coupleId, Long requesterId, LocalDateTime disconnectedAt, Long durationDays) {
+        return new CoupleDisconnectResponse(coupleId, requesterId, disconnectedAt, durationDays);
+    }
+}

--- a/backend/src/main/java/com/kongdak/controller/dto/response/CoupleInfo.java
+++ b/backend/src/main/java/com/kongdak/controller/dto/response/CoupleInfo.java
@@ -22,10 +22,10 @@ public record CoupleInfo(
         @Schema(description = "연결 상태", example = "true")
         boolean isConnected
 ) {
-    public static CoupleInfo from(Couple couple, Long memberId) {
+    public static CoupleInfo from(Couple couple, Long partnerId) {
         return new CoupleInfo(
                 couple.getId(),
-                couple.getPartnerId(memberId),
+                partnerId,
                 couple.getConnectedAt(),
                 couple.getAnniversaryDate(),
                 couple.isConnected()

--- a/backend/src/main/java/com/kongdak/controller/dto/response/CoupleResponse.java
+++ b/backend/src/main/java/com/kongdak/controller/dto/response/CoupleResponse.java
@@ -1,6 +1,9 @@
 package com.kongdak.controller.dto.response;
 
 import com.kongdak.domain.couple.Couple;
+import com.kongdak.domain.member.MemberRepository;
+import com.kongdak.global.exception.BusinessException;
+import com.kongdak.global.exception.ErrorCode;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
@@ -22,10 +25,10 @@ public record CoupleResponse(
         @Schema(description = "연결 상태", example = "true")
         boolean isConnected
 ) {
-    public static CoupleResponse from(Couple couple, Long memberId) {
+    public static CoupleResponse of(Couple couple, Long partnerId) {
         return new CoupleResponse(
                 couple.getId(),
-                couple.getPartnerId(memberId),
+                partnerId,
                 couple.getConnectedAt(),
                 couple.getAnniversaryDate(),
                 couple.isConnected()

--- a/backend/src/main/java/com/kongdak/controller/dto/response/CoupleRestoreResponse.java
+++ b/backend/src/main/java/com/kongdak/controller/dto/response/CoupleRestoreResponse.java
@@ -1,0 +1,27 @@
+package com.kongdak.controller.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+@Schema(description = "커플 연결 복구 응답")
+public record CoupleRestoreResponse(
+        @Schema(description = "커플 ID", example = "1")
+        Long coupleId,
+
+        @Schema(description = "복구 요청자 ID", example = "2")
+        Long requesterId,
+
+        @Schema(description = "연결 복구 시간", example = "2024-01-19T18:30:00")
+        LocalDateTime restoredAt,
+
+        @Schema(description = "원래 연결 시작 시간", example = "2023-12-25T00:00:00")
+        LocalDateTime originalConnectedAt
+) {
+    public static CoupleRestoreResponse of(
+            Long coupleId,
+            Long requesterId,
+            LocalDateTime restoredAt,
+            LocalDateTime originalConnectedAt) {
+        return new CoupleRestoreResponse(coupleId, requesterId, restoredAt, originalConnectedAt);
+    }
+}

--- a/backend/src/main/java/com/kongdak/controller/dto/response/DailyQuestionResponse.java
+++ b/backend/src/main/java/com/kongdak/controller/dto/response/DailyQuestionResponse.java
@@ -2,9 +2,11 @@ package com.kongdak.controller.dto.response;
 
 import com.kongdak.domain.dailyquestion.DailyQuestion;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
 
 import java.time.LocalDateTime;
 
+@Builder
 @Schema(description = "데일리 질문 응답")
 public record DailyQuestionResponse(
         @Schema(description = "질문 ID", example = "1")

--- a/backend/src/main/java/com/kongdak/controller/dto/response/DeactivateResponse.java
+++ b/backend/src/main/java/com/kongdak/controller/dto/response/DeactivateResponse.java
@@ -1,0 +1,18 @@
+package com.kongdak.controller.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+// Response DTO
+@Schema(description = "회원 탈퇴 응답")
+public record DeactivateResponse(
+        @Schema(description = "탈퇴 처리된 이메일", example = "user@example.com")
+        String email,
+
+        @Schema(description = "탈퇴 처리 시간", example = "2024-01-19T18:30:00")
+        LocalDateTime deactivatedAt,
+
+        @Schema(description = "처리 상태 메시지", example = "회원 탈퇴가 완료되었습니다.")
+        String message
+) {}

--- a/backend/src/main/java/com/kongdak/controller/dto/response/DiaryDeleteResponse.java
+++ b/backend/src/main/java/com/kongdak/controller/dto/response/DiaryDeleteResponse.java
@@ -1,0 +1,30 @@
+package com.kongdak.controller.dto.response;
+
+import com.kongdak.domain.diary.Diary;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.time.LocalDate;
+
+@Schema(description = "다이어리 삭제 응답")
+public record DiaryDeleteResponse(
+        @Schema(description = "삭제된 다이어리 ID", example = "1")
+        Long diaryId,
+
+        @Schema(description = "커플 ID", example = "1")
+        Long coupleId,
+
+        @Schema(description = "다이어리 작성 날짜", example = "2024-01-19")
+        LocalDate diaryDate,
+
+        @Schema(description = "삭제 시간", example = "2024-01-19T18:30:00")
+        LocalDateTime deletedAt
+) {
+    public static DiaryDeleteResponse of(Diary diary) {
+        return new DiaryDeleteResponse(
+                diary.getId(),
+                diary.getCouple().getId(),
+                diary.getDiaryDate(),
+                LocalDateTime.now()
+        );
+    }
+}

--- a/backend/src/main/java/com/kongdak/controller/dto/response/DiaryDetailResponse.java
+++ b/backend/src/main/java/com/kongdak/controller/dto/response/DiaryDetailResponse.java
@@ -36,13 +36,8 @@ public record DiaryDetailResponse(
         LocalDateTime createdAt,
 
         @Schema(description = "수정 시간", example = "2024-01-10T12:30:00")
-        LocalDateTime updatedAt,
+        LocalDateTime updatedAt
 
-        @Schema(description = "편집 중 여부", example = "true")
-        Boolean isEditing,
-
-        @Schema(description = "현재 편집자 ID", example = "1", nullable = true)
-        Long editorId
 ) {
     public static DiaryDetailResponse from(Diary diary) {
         return new DiaryDetailResponse(
@@ -58,9 +53,7 @@ public record DiaryDetailResponse(
                         .map(DecorationResponse::from)
                         .toList(),
                 diary.getCreatedAt(),
-                diary.getUpdatedAt(),
-                diary.isEditing(),
-                diary.getEditor() != null ? diary.getEditor().getId() : null
+                diary.getUpdatedAt()
         );
     }
 }

--- a/backend/src/main/java/com/kongdak/controller/dto/response/DiaryUpdateResponse.java
+++ b/backend/src/main/java/com/kongdak/controller/dto/response/DiaryUpdateResponse.java
@@ -1,0 +1,26 @@
+package com.kongdak.controller.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.HashMap;
+
+@Schema(description = "다이어리 수정 응답")
+public record DiaryUpdateResponse(
+        @Schema(description = "다이어리 ID", example = "1")
+        Long diaryId,
+
+        @Schema(description = "변경된 필드 목록")
+        Map<String, Object> changedFields,
+
+        @Schema(description = "수정 시간", example = "2024-01-19T18:30:00")
+        LocalDateTime updatedAt
+) {
+    public static DiaryUpdateResponse of(Long diaryId, Map<String, Object> changedFields) {
+        return new DiaryUpdateResponse(
+                diaryId,
+                changedFields,
+                LocalDateTime.now()
+        );
+    }
+}

--- a/backend/src/main/java/com/kongdak/controller/dto/response/MatchAcceptResponse.java
+++ b/backend/src/main/java/com/kongdak/controller/dto/response/MatchAcceptResponse.java
@@ -1,0 +1,22 @@
+package com.kongdak.controller.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+@Schema(description = "커플 매칭 수락 응답")
+public record MatchAcceptResponse(
+        @Schema(description = "요청자 ID", example = "1")
+        Long requesterId,
+
+        @Schema(description = "수락자 ID", example = "2")
+        Long accepterId,
+
+        @Schema(description = "매칭 성사 시간", example = "2024-01-19T18:30:00")
+        LocalDateTime matchedAt
+) {
+    public static MatchAcceptResponse of(Long requesterId, Long accepterId, LocalDateTime matchedAt) {
+        return new MatchAcceptResponse(requesterId, accepterId, matchedAt);
+    }
+}
+
+

--- a/backend/src/main/java/com/kongdak/controller/dto/response/MatchRejectResponse.java
+++ b/backend/src/main/java/com/kongdak/controller/dto/response/MatchRejectResponse.java
@@ -1,0 +1,21 @@
+package com.kongdak.controller.dto.response;
+
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+@Schema(description = "커플 매칭 거절 응답")
+public record MatchRejectResponse(
+        @Schema(description = "요청자 ID", example = "1")
+        Long requesterId,
+
+        @Schema(description = "거절자 ID", example = "2")
+        Long rejecterId,
+
+        @Schema(description = "거절 시간", example = "2024-01-19T18:30:00")
+        LocalDateTime rejectedAt
+) {
+    public static MatchRejectResponse of(Long requesterId, Long rejecterId, LocalDateTime rejectedAt) {
+        return new MatchRejectResponse(requesterId, rejecterId, rejectedAt);
+    }
+}

--- a/backend/src/main/java/com/kongdak/controller/dto/response/MatchRequestResponse.java
+++ b/backend/src/main/java/com/kongdak/controller/dto/response/MatchRequestResponse.java
@@ -1,0 +1,20 @@
+package com.kongdak.controller.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "커플 매칭 요청 응답")
+public record MatchRequestResponse(
+        @Schema(description = "매칭 요청 ID", example = "123456")
+        String requestId,
+
+        @Schema(description = "요청자 ID", example = "1")
+        Long requesterId,
+
+        @Schema(description = "대상자 ID", example = "2")
+        Long targetId,
+
+        @Schema(description = "요청 시간", example = "2024-01-19T18:30:00")
+        LocalDateTime requestedAt
+) {}

--- a/backend/src/main/java/com/kongdak/controller/dto/response/MemberResponse.java
+++ b/backend/src/main/java/com/kongdak/controller/dto/response/MemberResponse.java
@@ -1,6 +1,7 @@
 package com.kongdak.controller.dto.response;
 
 import com.kongdak.domain.member.Member;
+import com.kongdak.domain.member.MemberRepository;
 import com.kongdak.domain.member.OAuthProvider;
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -29,7 +30,7 @@ public record MemberResponse(
         CoupleInfo coupleInfo
 
 ) {
-    public static MemberResponse from(Member member){
+    public static MemberResponse from(Member member, Member partner){
         return new MemberResponse(
             member.getId(),
                 member.getNickname(),
@@ -37,7 +38,7 @@ public record MemberResponse(
                 member.getOauthProvider(),
                 member.getCreatedAt(),
                 member.isActive(),
-                member.getCouple() != null ? CoupleInfo.from(member.getCouple(), member.getId()) : null
+                member.getCouple() != null ? CoupleInfo.from(member.getCouple(), partner.getId()) : null
         );
     }
 }

--- a/backend/src/main/java/com/kongdak/controller/dto/response/ReplyCreateResponse.java
+++ b/backend/src/main/java/com/kongdak/controller/dto/response/ReplyCreateResponse.java
@@ -1,0 +1,33 @@
+package com.kongdak.controller.dto.response;
+
+import com.kongdak.domain.dailyquestion.AnswerReply;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+@Schema(description = "답변 댓글 추가 응답")
+public record ReplyCreateResponse(
+        @Schema(description = "생성된 댓글 ID", example = "1")
+        Long replyId,
+
+        @Schema(description = "질문 ID", example = "1")
+        Long questionId,
+
+        @Schema(description = "작성자 ID", example = "1")
+        Long memberId,
+
+        @Schema(description = "댓글 내용", example = "정말 좋은 생각이에요!")
+        String content,
+
+        @Schema(description = "생성 시간", example = "2024-01-19T18:30:00")
+        LocalDateTime createdAt
+) {
+    public static ReplyCreateResponse from(AnswerReply reply) {
+        return new ReplyCreateResponse(
+                reply.getId(),
+                reply.getQuestion().getId(),
+                reply.getMember().getId(),
+                reply.getContent(),
+                reply.getCreatedAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/kongdak/controller/dto/response/ReplyDeleteResponse.java
+++ b/backend/src/main/java/com/kongdak/controller/dto/response/ReplyDeleteResponse.java
@@ -1,0 +1,29 @@
+package com.kongdak.controller.dto.response;
+
+import com.kongdak.domain.dailyquestion.AnswerReply;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+@Schema(description = "답변 댓글 삭제 응답")
+public record ReplyDeleteResponse(
+        @Schema(description = "삭제된 댓글 ID", example = "1")
+        Long replyId,
+
+        @Schema(description = "질문 ID", example = "1")
+        Long questionId,
+
+        @Schema(description = "작성자 ID", example = "1")
+        Long memberId,
+
+        @Schema(description = "삭제 시간", example = "2024-01-19T18:30:00")
+        LocalDateTime deletedAt
+) {
+    public static ReplyDeleteResponse of(AnswerReply reply) {
+        return new ReplyDeleteResponse(
+                reply.getId(),
+                reply.getQuestion().getId(),
+                reply.getMember().getId(),
+                LocalDateTime.now()
+        );
+    }
+}

--- a/backend/src/main/java/com/kongdak/controller/dto/response/ScheduleDeleteResponse.java
+++ b/backend/src/main/java/com/kongdak/controller/dto/response/ScheduleDeleteResponse.java
@@ -1,0 +1,27 @@
+package com.kongdak.controller.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+@Schema(description = "일정 삭제 응답")
+public record ScheduleDeleteResponse(
+        @Schema(description = "삭제된 일정 ID", example = "1")
+        Long scheduleId,
+
+        @Schema(description = "캘린더 ID", example = "1")
+        Long calendarId,
+
+        @Schema(description = "삭제된 일정 제목", example = "데이트")
+        String scheduleTitle,
+
+        @Schema(description = "삭제 시간", example = "2024-01-19T18:30:00")
+        LocalDateTime deletedAt
+) {
+    public static ScheduleDeleteResponse of(
+            Long scheduleId,
+            Long calendarId,
+            String scheduleTitle,
+            LocalDateTime deletedAt) {
+        return new ScheduleDeleteResponse(scheduleId, calendarId, scheduleTitle, deletedAt);
+    }
+}

--- a/backend/src/main/java/com/kongdak/domain/calendar/CalendarService.java
+++ b/backend/src/main/java/com/kongdak/domain/calendar/CalendarService.java
@@ -137,14 +137,23 @@ public class CalendarService {
 
     // 일정 삭제
     @Transactional
-    public void deleteSchedule(Long calendarId, Long scheduleId) {
+    public ScheduleDeleteResponse deleteSchedule(Long calendarId, Long scheduleId) {
         Calendar calendar = findCalendarById(calendarId);
         Schedule schedule = findScheduleById(scheduleId);
 
         validateCalendarAccess(calendar);
         validateScheduleAccess(schedule);
 
+        String scheduleTitle = schedule.getTitle();
+
         scheduleRepository.delete(schedule);
+
+        return ScheduleDeleteResponse.of(
+                scheduleId,
+                calendarId,
+                scheduleTitle,
+                LocalDateTime.now()
+        );
     }
 
     private Calendar findCalendarById(Long calendarId) {
@@ -174,7 +183,7 @@ public class CalendarService {
         Member currentMember = memberService.getCurrentMember();
         Couple couple = calendar.getCouple();
 
-        if (!couple.containsMember(currentMember.getId())) {
+        if (!currentMember.getCouple().equals(couple)) {
             throw new BusinessException(ErrorCode.CALENDAR_ACCESS_DENIED);
         }
     }

--- a/backend/src/main/java/com/kongdak/domain/calendar/CalendarService.java
+++ b/backend/src/main/java/com/kongdak/domain/calendar/CalendarService.java
@@ -174,7 +174,7 @@ public class CalendarService {
         Member currentMember = memberService.getCurrentMember();
         Couple couple = calendar.getCouple();
 
-        if (!couple.getMember1().equals(currentMember) && !couple.getMember2().equals(currentMember)) {
+        if (!couple.containsMember(currentMember.getId())) {
             throw new BusinessException(ErrorCode.CALENDAR_ACCESS_DENIED);
         }
     }

--- a/backend/src/main/java/com/kongdak/domain/couple/Couple.java
+++ b/backend/src/main/java/com/kongdak/domain/couple/Couple.java
@@ -12,7 +12,6 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -23,9 +22,6 @@ public class Couple extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
-    @OneToMany(mappedBy = "couple")
-    private List<Member> members = new ArrayList<>();
 
     @Column(nullable = false)
     private LocalDateTime connectedAt;
@@ -38,41 +34,16 @@ public class Couple extends BaseTimeEntity {
     private LocalDateTime disconnectedAt;
 
     @Builder
-    public Couple(Member member1, Member member2, LocalDateTime anniversaryDate) {
-        validateMemberNotNull(member1, member2);
+    public Couple(LocalDateTime anniversaryDate) {
         this.connectedAt = LocalDateTime.now();
         this.isConnected = true;
         this.anniversaryDate = anniversaryDate;
-        connectMembers(member1, member2);
     }
 
-    private void validateMemberNotNull(Member member1, Member member2) {
-        if (member1 == null || member2 == null) {
+    private void validateMemberNotNull(List<Member> members) {
+        if (members == null || members.size() != 2) {
             throw new BusinessException(ErrorCode.MEMBER_NOT_FOUND);
         }
-    }
-
-    // 연관관계 편의 메서드
-    private void connectMembers(Member member1, Member member2) {
-        validateMemberSize();
-        this.members.add(member1);
-        this.members.add(member2);
-    }
-
-    // 커플 멤버 수 검증
-    private void validateMemberSize() {
-        if (!members.isEmpty()) {
-            throw new BusinessException(ErrorCode.COUPLE_ALREADY_EXISTS);
-        }
-    }
-
-    // 파트너 ID를 가져오는 메서드
-    public Long getPartnerId(Long memberId) {
-        return members.stream()
-                .filter(member -> !member.getId().equals(memberId))
-                .map(Member::getId)
-                .findFirst()
-                .orElseThrow(() -> new BusinessException(ErrorCode.PARTNER_NOT_FOUND));
     }
 
     public void disconnect() {
@@ -106,9 +77,4 @@ public class Couple extends BaseTimeEntity {
         }
     }
 
-    // 멤버가 이 커플에 속해있는지 확인
-    public boolean containsMember(Long memberId) {
-        return members.stream()
-                .anyMatch(member -> member.getId().equals(memberId));
-    }
 }

--- a/backend/src/main/java/com/kongdak/domain/couple/Couple.java
+++ b/backend/src/main/java/com/kongdak/domain/couple/Couple.java
@@ -12,6 +12,8 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -22,13 +24,8 @@ public class Couple extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member1_id")
-    private Member member1;
-
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member2_id")
-    private Member member2;
+    @OneToMany(mappedBy = "couple")
+    private List<Member> members = new ArrayList<>();
 
     @Column(nullable = false)
     private LocalDateTime connectedAt;
@@ -42,27 +39,49 @@ public class Couple extends BaseTimeEntity {
 
     @Builder
     public Couple(Member member1, Member member2, LocalDateTime anniversaryDate) {
-        this.member1 = member1;
-        this.member2 = member2;
+        validateMemberNotNull(member1, member2);
         this.connectedAt = LocalDateTime.now();
         this.isConnected = true;
         this.anniversaryDate = anniversaryDate;
+        connectMembers(member1, member2);
+    }
+
+    private void validateMemberNotNull(Member member1, Member member2) {
+        if (member1 == null || member2 == null) {
+            throw new BusinessException(ErrorCode.MEMBER_NOT_FOUND);
+        }
+    }
+
+    // 연관관계 편의 메서드
+    private void connectMembers(Member member1, Member member2) {
+        validateMemberSize();
+        this.members.add(member1);
+        this.members.add(member2);
+    }
+
+    // 커플 멤버 수 검증
+    private void validateMemberSize() {
+        if (!members.isEmpty()) {
+            throw new BusinessException(ErrorCode.COUPLE_ALREADY_EXISTS);
+        }
     }
 
     // 파트너 ID를 가져오는 메서드
     public Long getPartnerId(Long memberId) {
-        if (member1.getId().equals(memberId)) {
-            return member2.getId();
-        }
-        return member1.getId();
+        return members.stream()
+                .filter(member -> !member.getId().equals(memberId))
+                .map(Member::getId)
+                .findFirst()
+                .orElseThrow(() -> new BusinessException(ErrorCode.PARTNER_NOT_FOUND));
     }
 
-    public void disconnect(){
+    public void disconnect() {
+        validateConnected();
         this.isConnected = false;
         this.disconnectedAt = LocalDateTime.now();
     }
 
-    public void restore(){
+    public void restore() {
         validateCanRestore();
         this.isConnected = true;
         this.disconnectedAt = null;
@@ -79,5 +98,17 @@ public class Couple extends BaseTimeEntity {
         if (!canRestore()) {
             throw new BusinessException(ErrorCode.CANNOT_RESTORE_COUPLE);
         }
+    }
+
+    private void validateConnected() {
+        if (!isConnected) {
+            throw new BusinessException(ErrorCode.COUPLE_ALREADY_DISCONNECTED);
+        }
+    }
+
+    // 멤버가 이 커플에 속해있는지 확인
+    public boolean containsMember(Long memberId) {
+        return members.stream()
+                .anyMatch(member -> member.getId().equals(memberId));
     }
 }

--- a/backend/src/main/java/com/kongdak/domain/couple/CoupleRepository.java
+++ b/backend/src/main/java/com/kongdak/domain/couple/CoupleRepository.java
@@ -6,15 +6,15 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface CoupleRepository extends JpaRepository<Couple, Long> {
-    Optional<Couple> findByMember1OrMember2(Member member1, Member member2);
 
-    @Query("SELECT c FROM Couple c WHERE c.member1.id = :memberId OR c.member2.id = :memberId")
+    @Query("SELECT m.couple FROM Member m WHERE m.id = :memberId")
     Optional<Couple> findByMemberId(@Param("memberId") Long memberId);
 
-    boolean existsByMember1OrMember2(Member member1, Member member2);
-
+    @Query("SELECT CASE WHEN COUNT(m) > 0 THEN true ELSE false END FROM Member m WHERE m IN (:members) AND m.couple IS NOT NULL")
+    boolean existsByMemberIn(@Param("members") List<Member> members);
 }

--- a/backend/src/main/java/com/kongdak/domain/couple/CoupleService.java
+++ b/backend/src/main/java/com/kongdak/domain/couple/CoupleService.java
@@ -1,10 +1,11 @@
 package com.kongdak.domain.couple;
 
 import com.kongdak.controller.dto.request.CoupleMatchRequest;
-import com.kongdak.controller.dto.response.CoupleResponse;
+import com.kongdak.controller.dto.response.*;
 import com.kongdak.domain.calendar.Calendar;
 import com.kongdak.domain.calendar.CalendarRepository;
 import com.kongdak.domain.member.Member;
+import com.kongdak.domain.member.MemberRepository;
 import com.kongdak.domain.member.MemberService;
 import com.kongdak.domain.notification.NotificationMessage;
 import com.kongdak.domain.notification.NotificationType;
@@ -17,6 +18,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
 import java.util.Random;
 
 @Service
@@ -26,6 +29,7 @@ import java.util.Random;
 public class CoupleService {
     private final CoupleRepository coupleRepository;
     private final MemberService memberService;
+    private final MemberRepository memberRepository;
     private final CalendarRepository calendarRepository;
     private final CoupleMatchRedisRepository coupleMatchRedisRepository;
     private final SseEmitterService sseEmitterService;
@@ -37,7 +41,7 @@ public class CoupleService {
 
     // 매칭 요청
     @Transactional
-    public void requestMatch(Long requesterId, String targetCode) {
+    public MatchRequestResponse requestMatch(Long requesterId, String targetCode) {
         Long targetId = coupleMatchRedisRepository.findMemberIdByCode(targetCode)
                 .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_MATCH_REQUEST_CODE));
 
@@ -54,12 +58,19 @@ public class CoupleService {
                 requesterId
         );
         sseEmitterService.sendToMember(targetId, notification);
+
+        return new MatchRequestResponse(
+                requestId,
+                requesterId,
+                targetId,
+                LocalDateTime.now()
+        );
     }
 
 
     // 매칭 수락
     @Transactional
-    public void acceptMatch(String requestId, Long memberId) {
+    public MatchAcceptResponse acceptMatch(String requestId, Long memberId) {
         log.info("[CoupleService - acceptMatch] - requestId : {} , memberId : {}", requestId, memberId);
         CoupleMatchRequest request = coupleMatchRedisRepository.findCoupleMatchRequest(requestId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.COUPLE_MATCH_REQUEST_NOT_FOUND));
@@ -69,8 +80,10 @@ public class CoupleService {
         }
 
         log.info("[CoupleService - acceptMatch] - request.requesterId : {} , memberId : {}", request.requesterId(), memberId);
+
+        LocalDateTime matchedAt = LocalDateTime.now();
         // 커플 연결 처리
-        connect(request.requesterId(), memberId, LocalDateTime.now());
+        connect(request.requesterId(), memberId, matchedAt);
 
         // 매칭 요청 삭제
         coupleMatchRedisRepository.deleteMatchRequest(requestId);
@@ -83,10 +96,12 @@ public class CoupleService {
         );
         sseEmitterService.sendToMember(request.requesterId(), notification);
         sseEmitterService.sendToMember(memberId, notification);
+
+        return MatchAcceptResponse.of(request.requesterId(), memberId, matchedAt);
     }
 
     // 매칭 거절
-    public void rejectMatch(String requestId, Long memberId) {
+    public MatchRejectResponse rejectMatch(String requestId, Long memberId) {
         CoupleMatchRequest request = coupleMatchRedisRepository.findCoupleMatchRequest(requestId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.COUPLE_MATCH_REQUEST_NOT_FOUND));
 
@@ -103,6 +118,12 @@ public class CoupleService {
                 null
         );
         sseEmitterService.sendToMember(request.requesterId(), notification);
+
+        return MatchRejectResponse.of(
+                request.requesterId(),
+                memberId,
+                LocalDateTime.now()
+        );
     }
 
     @Transactional
@@ -116,11 +137,11 @@ public class CoupleService {
         // 먼저 Couple을 저장
         Couple couple = coupleRepository.save(
                 Couple.builder()
-                        .member1(member)
-                        .member2(partner)
                         .anniversaryDate(anniversaryDate)
                         .build()
         );
+        member.setCouple(couple);
+        partner.setCouple(couple);
 
         // Calendar도 생성되어야 한다.
         Calendar calendar = Calendar.builder()
@@ -128,22 +149,42 @@ public class CoupleService {
                 .build();
         calendarRepository.save(calendar);
 
-        coupleRepository.save(couple);
-        return CoupleResponse.from(couple, memberId);
+        return CoupleResponse.from(couple, memberId, memberRepository);
     }
 
     @Transactional
-    public void disconnect(Long coupleId, Long memberId) {
+    public CoupleDisconnectResponse disconnect(Long coupleId, Long memberId) {
         Couple couple = findCoupleById(coupleId);
         validateMemberInCouple(couple, memberId);
+
+        LocalDateTime disconnectedAt = LocalDateTime.now();
+        Long durationDays = ChronoUnit.DAYS.between(couple.getConnectedAt(), disconnectedAt);
         couple.disconnect();
+
+        return CoupleDisconnectResponse.of(
+                coupleId,
+                memberId,
+                disconnectedAt,
+                durationDays
+        );
     }
 
     @Transactional
-    public void restore(Long coupleId, Long memberId) {
+    public CoupleRestoreResponse restore(Long coupleId, Long memberId) {
         Couple couple = findCoupleById(coupleId);
         validateMemberInCouple(couple, memberId);
+
+        LocalDateTime restoredAt = LocalDateTime.now();
+        LocalDateTime originalConnectedAt = couple.getConnectedAt();
+
         couple.restore();
+
+        return CoupleRestoreResponse.of(
+                coupleId,
+                memberId,
+                restoredAt,
+                originalConnectedAt
+        );
     }
 
     public Couple findCoupleById(Long coupleId) {
@@ -153,16 +194,16 @@ public class CoupleService {
     }
 
     private void validateConnection(Member member, Member partner) {
-        if (coupleRepository.existsByMember1OrMember2(member, member)) {
+        if (coupleRepository.existsByMemberIn(List.of(member, partner))) {
             throw new BusinessException(ErrorCode.MEMBER_ALREADY_COUPLED);
-        }
-        if (coupleRepository.existsByMember1OrMember2(partner, partner)) {
-            throw new BusinessException(ErrorCode.PARTNER_ALREADY_COUPLED);
         }
     }
 
     private void validateMemberInCouple(Couple couple, Long memberId) {
-        if (!couple.containsMember(memberId)) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+
+        if (!couple.equals(member.getCouple())) {
             throw new BusinessException(ErrorCode.NOT_COUPLE_MEMBER);
         }
     }

--- a/backend/src/main/java/com/kongdak/domain/couple/CoupleService.java
+++ b/backend/src/main/java/com/kongdak/domain/couple/CoupleService.java
@@ -162,8 +162,7 @@ public class CoupleService {
     }
 
     private void validateMemberInCouple(Couple couple, Long memberId) {
-        if (!couple.getMember1().getId().equals(memberId) &&
-                !couple.getMember2().getId().equals(memberId)) {
+        if (!couple.containsMember(memberId)) {
             throw new BusinessException(ErrorCode.NOT_COUPLE_MEMBER);
         }
     }

--- a/backend/src/main/java/com/kongdak/domain/couple/CoupleService.java
+++ b/backend/src/main/java/com/kongdak/domain/couple/CoupleService.java
@@ -149,7 +149,7 @@ public class CoupleService {
                 .build();
         calendarRepository.save(calendar);
 
-        return CoupleResponse.from(couple, memberId, memberRepository);
+        return CoupleResponse.of(couple, partnerId);
     }
 
     @Transactional

--- a/backend/src/main/java/com/kongdak/domain/dailyquestion/DailyAnswerRepository.java
+++ b/backend/src/main/java/com/kongdak/domain/dailyquestion/DailyAnswerRepository.java
@@ -1,6 +1,8 @@
 package com.kongdak.domain.dailyquestion;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -12,4 +14,20 @@ public interface DailyAnswerRepository extends JpaRepository<DailyAnswer, Long> 
     List<DailyAnswer> findByQuestionId(Long questionId);
     // 특정 멤버의 답변 조회
     Optional<DailyAnswer> findByQuestionIdAndMemberId(Long questionId, Long memberId);
+
+    // 특정 멤버의 마지막 답변 조회
+    @Query("SELECT da FROM DailyAnswer da " +
+            "WHERE da.member.id = :memberId " +
+            "ORDER BY da.question.id DESC")
+    Optional<DailyAnswer> findLastAnswerByMemberId(@Param("memberId") Long memberId);
+
+    // 특정 커플(두 멤버)의 답변 여부 확인
+    @Query("SELECT COUNT(da) FROM DailyAnswer da " +
+            "WHERE da.question.id = :questionId " +
+            "AND da.member.id IN (:member1Id, :member2Id)")
+    long countAnswersByQuestionAndMembers(
+            @Param("questionId") Long questionId,
+            @Param("member1Id") Long member1Id,
+            @Param("member2Id") Long member2Id
+    );
 }

--- a/backend/src/main/java/com/kongdak/domain/dailyquestion/DailyQuestionRepository.java
+++ b/backend/src/main/java/com/kongdak/domain/dailyquestion/DailyQuestionRepository.java
@@ -1,6 +1,8 @@
 package com.kongdak.domain.dailyquestion;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
@@ -8,8 +10,14 @@ import java.util.Optional;
 
 @Repository
 public interface DailyQuestionRepository extends JpaRepository<DailyQuestion, Long> {
-    // 오늘의 질문 조회
-    Optional<DailyQuestion> findByCreatedAtBetween(LocalDateTime start, LocalDateTime end);
+    // 첫 번째 질문 조회
+    Optional<DailyQuestion> findFirstByOrderByIdAsc();
+
+    // 특정 ID 이후의 다음 질문 조회
+    @Query("SELECT dq FROM DailyQuestion dq " +
+            "WHERE dq.id > :questionId " +
+            "ORDER BY dq.id ASC")
+    Optional<DailyQuestion> findNextQuestion(@Param("questionId") Long questionId);
 }
 
 

--- a/backend/src/main/java/com/kongdak/domain/dailyquestion/DailyQuestionService.java
+++ b/backend/src/main/java/com/kongdak/domain/dailyquestion/DailyQuestionService.java
@@ -3,8 +3,7 @@ package com.kongdak.domain.dailyquestion;
 import com.kongdak.controller.dto.request.DailyAnswerRequest;
 import com.kongdak.controller.dto.request.EmojiRequest;
 import com.kongdak.controller.dto.request.ReplyRequest;
-import com.kongdak.controller.dto.response.DailyAnswerResponse;
-import com.kongdak.controller.dto.response.DailyQuestionResponse;
+import com.kongdak.controller.dto.response.*;
 import com.kongdak.domain.couple.Couple;
 import com.kongdak.domain.couple.CoupleRepository;
 import com.kongdak.domain.member.Member;
@@ -117,7 +116,7 @@ public class DailyQuestionService {
 
     // 이모지 반응 추가
     @Transactional
-    public void addEmoji(Long memberId, Long answerId, EmojiRequest request) {
+    public AnswerEmojiResponse addEmoji(Long memberId, Long answerId, EmojiRequest request) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
 
@@ -135,12 +134,13 @@ public class DailyQuestionService {
                 .emoji(request.emoji())
                 .build();
 
-        answerEmojiRepository.save(answerEmoji);
+        AnswerEmoji savedEmoji = answerEmojiRepository.save(answerEmoji);
+        return AnswerEmojiResponse.from(savedEmoji);
     }
 
     // 댓글 작성
     @Transactional
-    public void addReply(Long memberId, Long questionId, ReplyRequest request) {
+    public ReplyCreateResponse addReply(Long memberId, Long questionId, ReplyRequest request) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
 
@@ -160,11 +160,13 @@ public class DailyQuestionService {
                 .build();
 
         answerReplyRepository.save(reply);
+
+        return ReplyCreateResponse.from(reply);
     }
 
     // 댓글 삭제
     @Transactional
-    public void deleteReply(Long memberId, Long questionId, Long replyId) {
+    public ReplyDeleteResponse deleteReply(Long memberId, Long questionId, Long replyId) {
         AnswerReply reply = answerReplyRepository.findById(replyId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.REPLY_NOT_FOUND));
 
@@ -172,7 +174,9 @@ public class DailyQuestionService {
         if (!reply.getMember().getId().equals(memberId)) {
             throw new BusinessException(ErrorCode.NOT_YOUR_REPLY);
         }
-
+        ReplyDeleteResponse response = ReplyDeleteResponse.of(reply);
         answerReplyRepository.delete(reply);
+
+        return response;
     }
 }

--- a/backend/src/main/java/com/kongdak/domain/dailyquestion/DailyQuestionService.java
+++ b/backend/src/main/java/com/kongdak/domain/dailyquestion/DailyQuestionService.java
@@ -5,19 +5,23 @@ import com.kongdak.controller.dto.request.EmojiRequest;
 import com.kongdak.controller.dto.request.ReplyRequest;
 import com.kongdak.controller.dto.response.DailyAnswerResponse;
 import com.kongdak.controller.dto.response.DailyQuestionResponse;
+import com.kongdak.domain.couple.Couple;
+import com.kongdak.domain.couple.CoupleRepository;
 import com.kongdak.domain.member.Member;
 import com.kongdak.domain.member.MemberRepository;
 import com.kongdak.global.exception.BusinessException;
 import com.kongdak.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class DailyQuestionService {
@@ -26,16 +30,35 @@ public class DailyQuestionService {
     private final AnswerReplyRepository answerReplyRepository;
     private final AnswerEmojiRepository answerEmojiRepository;
     private final MemberRepository memberRepository;
+    private final CoupleRepository coupleRepository;
 
     // 오늘의 질문 조회
-    public DailyQuestionResponse getDailyQuestion() {
-        LocalDateTime startOfDay = LocalDateTime.now().withHour(0).withMinute(0).withSecond(0);
-        LocalDateTime endOfDay = startOfDay.plusDays(1);
+    public DailyQuestionResponse getDailyQuestion(Long memberId) {
 
-        DailyQuestion question = dailyQuestionRepository.findByCreatedAtBetween(startOfDay, endOfDay)
-                .orElseThrow(() -> new BusinessException(ErrorCode.QUESTION_NOT_FOUND));
+        // 현재 회원의 커플 정보 조회
+        Couple couple = coupleRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.COUPLE_NOT_FOUND));
 
-        return DailyQuestionResponse.from(question);
+        // 현재 회원의 마지막 답변 조회
+        Optional<DailyAnswer> lastAnswer =
+                dailyAnswerRepository.findLastAnswerByMemberId(memberId);
+        // 다음 질문 조회
+        DailyQuestion nextQuestion;
+        if (lastAnswer.isEmpty()) {
+            // 첫 번째 질문 조회
+            nextQuestion = dailyQuestionRepository.findFirstByOrderByIdAsc()
+                    .orElseThrow(() -> new BusinessException(ErrorCode.QUESTION_NOT_FOUND));
+        } else {
+            // 마지막 답변의 다음 질문 조회
+            nextQuestion = dailyQuestionRepository.findNextQuestion(lastAnswer.get().getQuestion().getId())
+                    .orElseThrow(() -> new BusinessException(ErrorCode.QUESTION_NOT_FOUND));
+        }
+
+        return DailyQuestionResponse.builder()
+                .questionId(nextQuestion.getId())
+                .title(nextQuestion.getTitle())
+                .build();
+
     }
 
     // 답변 작성
@@ -67,8 +90,11 @@ public class DailyQuestionService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
 
+        log.info("[DailyQuestionService - getAnswers]- memberId : {}", memberId);
         // 커플 관계 확인
         Long coupleId = member.getCoupleId();
+        log.info("[DailyQuestionService - getAnswers]- Couple 엔티티: {}", member.getCouple());
+        log.info("[DailyQuestionService - getAnswers]- coupleId : {}", coupleId);
         if (coupleId == null) {
             throw new BusinessException(ErrorCode.COUPLE_NOT_FOUND);
         }

--- a/backend/src/main/java/com/kongdak/domain/diary/Diary.java
+++ b/backend/src/main/java/com/kongdak/domain/diary/Diary.java
@@ -30,7 +30,6 @@ public class Diary extends BaseTimeEntity {
     private String content;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
     private Emotion emotion;
 
     @Enumerated(EnumType.STRING)
@@ -39,12 +38,6 @@ public class Diary extends BaseTimeEntity {
 
     @Column(nullable = false)
     private LocalDate diaryDate;
-
-    private boolean isEditing;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "editor_id")
-    private Member editor;
 
     @OneToMany(mappedBy = "diary", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<DiaryPhoto> photos = new ArrayList<>();
@@ -66,18 +59,6 @@ public class Diary extends BaseTimeEntity {
         this.content = content;
         this.emotion = emotion;
         this.weather = weather;
-    }
-
-    // 편집 잠금
-    public void startEditing(Member editor) {
-        this.isEditing = true;
-        this.editor = editor;
-    }
-
-    // 편집 잠금 해제
-    public void finishEditing() {
-        this.isEditing = false;
-        this.editor = null;
     }
 
     // 사진 추가

--- a/backend/src/main/java/com/kongdak/domain/diary/DiaryService.java
+++ b/backend/src/main/java/com/kongdak/domain/diary/DiaryService.java
@@ -70,6 +70,7 @@ public class DiaryService {
                 DiaryDecoration decoration = DiaryDecoration.builder()
                         .type(dec.type())
                         .content(dec.content())
+
                         .positionX(dec.positionX())
                         .positionY(dec.positionY())
                         .style(dec.style())
@@ -124,21 +125,13 @@ public class DiaryService {
     @Transactional
     public boolean acquireLock(Long diaryId, Long memberId) {
         String lockKey = "diary:" + diaryId;
-        if (redisLockRepository.acquireLock(lockKey, memberId.toString(), LOCK_DURATION)) {
-            Diary diary = getDiaryByIdAndMemberId(diaryId, memberId);
-            diary.startEditing(getMemberById(memberId));
-            return true;
-        }
-        return false;
+        return redisLockRepository.acquireLock(lockKey, memberId.toString(), LOCK_DURATION);
     }
 
     @Transactional
     public void releaseLock(Long diaryId, Long memberId) {
         String lockKey = "diary:" + diaryId;
-        if (redisLockRepository.releaseLock(lockKey, memberId.toString())) {
-            Diary diary = getDiaryByIdAndMemberId(diaryId, memberId);
-            diary.finishEditing();
-        }
+        redisLockRepository.releaseLock(lockKey, memberId.toString());
     }
 
     // Private 헬퍼 메서드
@@ -149,7 +142,9 @@ public class DiaryService {
     }
 
     private void validateDiaryEditable(Diary diary, Long memberId) {
-        if (diary.isEditing() && !memberId.equals(diary.getEditor().getId())) {
+        String lockKey = "diary:" + diary.getId();
+        String lockHolder = redisLockRepository.getLockHolder(lockKey);
+        if (lockHolder != null && !lockHolder.equals(memberId.toString())) {
             throw new BusinessException(ErrorCode.DIARY_BEING_EDITED);
         }
     }

--- a/backend/src/main/java/com/kongdak/domain/diary/DiaryService.java
+++ b/backend/src/main/java/com/kongdak/domain/diary/DiaryService.java
@@ -3,7 +3,9 @@ package com.kongdak.domain.diary;
 import com.kongdak.controller.dto.request.CreateDiaryRequest;
 import com.kongdak.controller.dto.request.DecorationUpdateRequest;
 import com.kongdak.controller.dto.request.UpdateDiaryRequest;
+import com.kongdak.controller.dto.response.DiaryDeleteResponse;
 import com.kongdak.controller.dto.response.DiaryDetailResponse;
+import com.kongdak.controller.dto.response.DiaryUpdateResponse;
 import com.kongdak.controller.dto.response.SearchDiaryResponse;
 import com.kongdak.domain.couple.CoupleRepository;
 import com.kongdak.domain.member.Member;
@@ -18,8 +20,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import com.kongdak.domain.couple.Couple;
 
@@ -83,24 +89,80 @@ public class DiaryService {
     }
 
     @Transactional
-    public void updateDiary(Long memberId, Long diaryId, UpdateDiaryRequest request) {
+    public DiaryUpdateResponse updateDiary(Long memberId, Long diaryId, UpdateDiaryRequest request) {
         Diary diary = getDiaryByIdAndMemberId(diaryId, memberId);
         validateDiaryEditable(diary, memberId);
 
         try {
+            Map<String, Object> changedFields = new HashMap<>();
+
+            // 기본 필드들 변경 확인
+            if (!diary.getContent().equals(request.content())) {
+                changedFields.put("content", request.content());
+            }
+            if (!diary.getEmotion().equals(request.emotion())) {
+                changedFields.put("emotion", request.emotion());
+            }
+            if (!diary.getWeather().equals(request.weather())) {
+                changedFields.put("weather", request.weather());
+            }
+
             // 기본 정보 업데이트
             diary.update(request.content(), request.emotion(), request.weather());
 
-            // 사진 업데이트
-            updatePhotos(diary, request.photoUrls());
+            // 사진 업데이트가 필요한지 확인
+            List<String> currentPhotoUrls = diary.getPhotos().stream()
+                    .map(DiaryPhoto::getPhotoUrl)
+                    .toList();
 
-            // 꾸미기 요소 업데이트
-            updateDecorations(diary, request.decorations());
+            if (!currentPhotoUrls.equals(request.photoUrls())) {
+                // 사진 목록이 변경됨
+                updatePhotos(diary, request.photoUrls());
+                Map<String, Object> photoInfo = new HashMap<>();
+                photoInfo.put("urls", request.photoUrls());
+                photoInfo.put("thumbnails", diary.getPhotos().stream()
+                        .map(DiaryPhoto::getThumbnailUrl)
+                        .collect(Collectors.toList()));
+                changedFields.put("photos", photoInfo);
+            }
+
+            // 꾸미기 요소 업데이트가 필요한지 확인
+            if (!compareDecorations(diary.getDecorations(), request.decorations())) {
+                updateDecorations(diary, request.decorations());
+                changedFields.put("decorations", request.decorations());
+            }
+
+            return DiaryUpdateResponse.of(
+                    diaryId,
+                    changedFields
+            );
         } finally {
-            // 편집 잠금 해제
             releaseLock(diaryId, memberId);
         }
     }
+
+    private boolean compareDecorations(List<DiaryDecoration> currentDecorations, List<DecorationUpdateRequest> requestDecorations) {
+        if (currentDecorations.size() != requestDecorations.size()) {
+            return false;
+        }
+
+        // 모든 속성이 동일한지 확인
+        for (int i = 0; i < currentDecorations.size(); i++) {
+            DiaryDecoration current = currentDecorations.get(i);
+            DecorationUpdateRequest request = requestDecorations.get(i);
+
+            if (!current.getType().equals(request.type()) ||
+                    !Objects.equals(current.getContent(), request.content()) ||
+                    !Objects.equals(current.getPositionX(), request.positionX()) ||
+                    !Objects.equals(current.getPositionY(), request.positionY()) ||
+                    !Objects.equals(current.getStyle(), request.style())) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
 
     public DiaryDetailResponse getDiary(Long memberId, Long diaryId) {
         Couple couple = getCoupleByMemberId(memberId);
@@ -115,11 +177,16 @@ public class DiaryService {
     }
 
     @Transactional
-    public void deleteDiary(Long memberId, Long diaryId) {
+    public DiaryDeleteResponse deleteDiary(Long memberId, Long diaryId) {
         Couple couple = getCoupleByMemberId(memberId);
         Diary diary = getDiaryByIdAndCoupleId(diaryId, couple.getId());
         validateDiaryEditable(diary, memberId);
+
+        // 삭제 전에 응답 DTO 생성
+        DiaryDeleteResponse response = DiaryDeleteResponse.of(diary);
         diaryRepository.delete(diary);
+
+        return response;
     }
 
     @Transactional

--- a/backend/src/main/java/com/kongdak/domain/member/Member.java
+++ b/backend/src/main/java/com/kongdak/domain/member/Member.java
@@ -29,7 +29,8 @@ public class Member extends BaseTimeEntity {
     @Column(nullable = false)
     private boolean isActive = true;
 
-    @ManyToOne
+    @Setter
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "couple_id")
     private Couple couple;
 
@@ -65,6 +66,5 @@ public class Member extends BaseTimeEntity {
     public void activate(){
         this.isActive = true;
     }
-
 
 }

--- a/backend/src/main/java/com/kongdak/domain/member/Member.java
+++ b/backend/src/main/java/com/kongdak/domain/member/Member.java
@@ -5,10 +5,7 @@ import com.kongdak.domain.couple.Couple;
 import com.kongdak.global.exception.BusinessException;
 import com.kongdak.global.exception.ErrorCode;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Getter
@@ -32,7 +29,7 @@ public class Member extends BaseTimeEntity {
     @Column(nullable = false)
     private boolean isActive = true;
 
-    @OneToOne
+    @ManyToOne
     @JoinColumn(name = "couple_id")
     private Couple couple;
 
@@ -68,4 +65,6 @@ public class Member extends BaseTimeEntity {
     public void activate(){
         this.isActive = true;
     }
+
+
 }

--- a/backend/src/main/java/com/kongdak/domain/member/MemberRepository.java
+++ b/backend/src/main/java/com/kongdak/domain/member/MemberRepository.java
@@ -1,7 +1,9 @@
 package com.kongdak.domain.member;
 
+import com.kongdak.domain.couple.Couple;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -18,4 +20,20 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     @Query("SELECT m FROM Member m WHERE m.isActive = true AND m.couple IS NULL")
     List<Member> findActiveUnconnectedMembers();
 
+    @Query("SELECT m.id FROM Member m WHERE m.couple = :couple AND m.id != :memberId")
+    Optional<Long> findPartnerIdByCoupleAndMemberIdNot(
+            @Param("couple") Couple couple,
+            @Param("memberId") Long memberId
+    );
+
+    // 특정 커플에 속한 모든 멤버 조회
+    @Query("SELECT m FROM Member m WHERE m.couple = :couple")
+    List<Member> findByCouple(@Param("couple") Couple couple);
+
+    // 특정 커플의 특정 멤버를 제외한 파트너 조회
+    @Query("SELECT m FROM Member m WHERE m.couple = :couple AND m.id != :memberId")
+    Optional<Member> findPartnerByCouple(
+            @Param("couple") Couple couple,
+            @Param("memberId") Long memberId
+    );
 }

--- a/backend/src/main/java/com/kongdak/domain/member/MemberService.java
+++ b/backend/src/main/java/com/kongdak/domain/member/MemberService.java
@@ -1,6 +1,8 @@
 package com.kongdak.domain.member;
 
 import com.kongdak.controller.dto.request.MemberCreateRequest;
+import com.kongdak.controller.dto.response.DeactivateResponse;
+import com.kongdak.controller.dto.response.MemberResponse;
 import com.kongdak.global.exception.BusinessException;
 import com.kongdak.global.exception.ErrorCode;
 import com.kongdak.global.security.SecurityUtil;
@@ -8,7 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Optional;
+import java.time.LocalDateTime;
 
 @Service
 @Transactional(readOnly = true)
@@ -43,18 +45,32 @@ public class MemberService {
     }
 
     @Transactional
-    public Member updateNickname(String email, String nickname) {
-        Member member = memberRepository.findByEmail(email).orElseThrow(
-                () -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND)
-        );
+    public MemberResponse updateNickname(String email, String nickname) {
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+
         member.updateNickname(nickname);
-        return member;
+
+        // 파트너 정보 조회
+        Member partner = null;
+        if (member.getCouple() != null) {
+            partner = memberRepository.findPartnerByCouple(member.getCouple(), member.getId())
+                    .orElse(null);
+        }
+
+        return MemberResponse.from(member, partner);
     }
 
     @Transactional
-    public void deactivateMember(String email) {
+    public DeactivateResponse deactivateMember(String email) {
         Member member = findByEmail(email);
         member.deactivate();
+
+        return new DeactivateResponse(
+                email,
+                LocalDateTime.now(),
+                "회원 탈퇴가 완료되었습니다."
+        );
     }
 
     public Member getCurrentMember() {
@@ -67,4 +83,21 @@ public class MemberService {
         return memberRepository.findByEmail(email)
                 .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
     }
+
+    @Transactional(readOnly = true)
+    public MemberResponse getMemberInfo(String email) {
+        Member member = findByEmail(email);
+        Member partner = null;
+
+        if (member.getCouple() != null) {
+            partner = memberRepository.findByCouple(member.getCouple()).stream()
+                    .filter(m -> !m.getId().equals(member.getId()))
+                    .findFirst()
+                    .orElse(null);
+        }
+
+        return MemberResponse.from(member, partner);
+    }
+
+
 }

--- a/backend/src/main/java/com/kongdak/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/kongdak/global/exception/ErrorCode.java
@@ -23,6 +23,10 @@ public enum ErrorCode {
     COUPLE_MATCH_REQUEST_NOT_FOUND(404, "C006", "커플 요청을 찾을 수 없습니다."),
     INVALID_MATCH_REQUEST_CODE(400, "C007", "유효하지 않은 코드입니다."),
     CANNOT_MATCH_TO_OWN(400, "C008", "스스로에게 커플 요청을 할 수 없습니다."),
+    COUPLE_ALREADY_EXISTS(400, "C009", "이미 커플이 맺어져 있습니다."),
+    PARTNER_NOT_FOUND(404, "C010", "파트너를 찾을 수 없습니다."),
+    COUPLE_ALREADY_DISCONNECTED(400, "C011", "이미 끊긴 커플입니다."),
+
 
     // Calendar 관련 예외
     CALENDAR_NOT_FOUND(404, "CL001", "캘린더를 찾을 수 없습니다"),


### PR DESCRIPTION
# 주요 변경사항

## 응답 구조 표준화
- 모든 API 응답에 대해 명확한 Response DTO 구조 도입
- CRUD 작업 결과를 더 자세히 전달하도록 개선
 - 생성/수정/삭제 작업 시 변경된 내용 상세 포함
 - 작업 수행 시간 정보 추가

## Member-Couple 관계 구조 개선
- Couple과 Member 간 관계를 OneToOne에서 OneToMany로 변경
- 양방향 연관관계를 단방향으로 개선하여 결합도 감소
- Member 엔티티의 Couple 참조 방식 개선

## 다이어리 편집 기능 개선
- 동시성 제어 로직을 Diary 엔티티에서 Redis로 이동
- 편집 중 상태 관리 방식 개선
- 다이어리 수정 시 변경된 필드만 응답하도록 개선

## 데일리 질문 기능 개선
- 질문 조회 로직을 시간 기반에서 순서 기반으로 변경
- 커플별 답변 관리 기능 강화
- 마지막 답변 기준 다음 질문 조회 기능 추가

# 상세 변경사항

## Controller 변경
- 모든 컨트롤러의 응답 형식 통일
- PathVariable ID 파라미터에 명시적 이름 지정
- Swagger 문서화 개선

## Service 변경
- 모든 서비스 메소드가 명확한 응답 객체 반환하도록 수정
- 불필요한 객체 변환 로직 제거
- 트랜잭션 처리 최적화

## Entity 변경
- Member와 Couple 엔티티 간 관계 재설계
- 다이어리 편집 관련 필드 제거 (Redis로 이동)
- NotNull 제약조건 일부 완화

# 테스트 진행사항
- [x] Member-Couple 관계 변경 관련 테스트
- [ ] API 응답 형식 변경 테스트
- [ ] 다이어리 편집 기능 테스트
- [ ] 데일리 질문 기능 테스트

# 참고사항
- Redis 구성 필요
- API 문서 업데이트 필요