### PR TITLE
데일리 질문과 캘린더 API 구조 개선 및 로직 최적화

### DIFF
--- a/backend/src/main/java/com/kongdak/config/JacksonConfig.java
+++ b/backend/src/main/java/com/kongdak/config/JacksonConfig.java
@@ -1,0 +1,28 @@
+package com.kongdak.config;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Configuration
+public class JacksonConfig {
+    @Bean
+    public Module javaTimeModule() {
+        JavaTimeModule module = new JavaTimeModule();
+        module.addDeserializer(LocalDateTime.class, new JsonDeserializer<LocalDateTime>() {
+            @Override
+            public LocalDateTime deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+                return LocalDateTime.parse(p.getValueAsString(), DateTimeFormatter.ISO_DATE_TIME);
+            }
+        });
+        return module;
+    }
+}

--- a/backend/src/main/java/com/kongdak/controller/CalendarController.java
+++ b/backend/src/main/java/com/kongdak/controller/CalendarController.java
@@ -8,7 +8,6 @@ import com.kongdak.controller.dto.response.ScheduleResponse;
 import com.kongdak.domain.calendar.CalendarService;
 import com.kongdak.global.response.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -19,7 +18,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.*;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
+import java.time.YearMonth;
 import java.util.List;
 
 @RestController
@@ -40,11 +40,10 @@ public class CalendarController {
                     content = @Content(schema = @Schema(implementation = BaseResponse.class))
             )
     })
-    @GetMapping("/{calendarId}/schedules/monthly")
+    @GetMapping("/schedules/monthly")
     public BaseResponse<MonthlyScheduleResponse> getMonthlySchedules(
-            @PathVariable Long calendarId,
-            @RequestParam("datetime") @DateTimeFormat(pattern = "yyyyMM") LocalDateTime dateTime) {
-        MonthlyScheduleResponse monthlySchedules = calendarService.getMonthlySchedules(calendarId, dateTime);
+            @RequestParam("datetime") @DateTimeFormat(pattern = "yyyyMM") YearMonth dateTime) {
+        MonthlyScheduleResponse monthlySchedules = calendarService.getMonthlySchedules(dateTime);
         return BaseResponse.ok(monthlySchedules);
     }
 
@@ -59,12 +58,13 @@ public class CalendarController {
                     content = @Content(schema = @Schema(implementation = BaseResponse.class))
             )
     })
-    @GetMapping("/{calendarId}/schedules/daily")
+    @GetMapping("/schedules/daily")
     public BaseResponse<List<ScheduleResponse>> getDailySchedules(
-            @PathVariable Long calendarId,
-            @RequestParam("datetime") @DateTimeFormat(pattern = "yyyyMMdd") LocalDateTime dateTime) {
+
+            @RequestParam("datetime")
+            @DateTimeFormat(pattern = "yyyyMMdd") LocalDate dateTime) {
         return BaseResponse.ok(
-                calendarService.getDailySchedules(calendarId, dateTime)
+                calendarService.getDailySchedules(dateTime)
         );
     }
 
@@ -79,11 +79,10 @@ public class CalendarController {
                     content = @Content(schema = @Schema(implementation = BaseResponse.class))
             )
     })
-    @GetMapping("/{calendarId}/schedules/{scheduleId}")
+    @GetMapping("/schedules/{scheduleId}")
     public BaseResponse<ScheduleDetailResponse> getScheduleDetail(
-            @PathVariable Long calendarId,
-            @PathVariable Long scheduleId) {
-        ScheduleDetailResponse scheduleDetail = calendarService.getScheduleDetail(calendarId, scheduleId);
+            @PathVariable("scheduleId") Long scheduleId) {
+        ScheduleDetailResponse scheduleDetail = calendarService.getScheduleDetail(scheduleId);
         return BaseResponse.ok(scheduleDetail);
     }
 
@@ -99,13 +98,10 @@ public class CalendarController {
                     content = @Content(schema = @Schema(implementation = BaseResponse.class))
             )
     })
-    @PostMapping("/{calendarId}/schedules")
+    @PostMapping("/schedules")
     public BaseResponse<ScheduleResponse> createSchedule(
-            @Parameter(description = "캘린더 ID", example = "1")
-            @PathVariable("calendarId") Long calendarId,
             @Valid @RequestBody ScheduleCreateRequest request) {
-        ScheduleResponse response = calendarService.createSchedule(calendarId, request);
-        return BaseResponse.created(response);
+        return BaseResponse.created(calendarService.createSchedule(request));
     }
 
 
@@ -120,12 +116,11 @@ public class CalendarController {
                     content = @Content(schema = @Schema(implementation = BaseResponse.class))
             )
     })
-    @PatchMapping("/{calendarId}/schedules/{scheduleId}")
+    @PatchMapping("/schedules/{scheduleId}")
     public BaseResponse<ScheduleResponse> updateSchedule(
-            @PathVariable Long calendarId,
-            @PathVariable Long scheduleId,
+            @PathVariable("scheduleId") Long scheduleId,
             @Valid @RequestBody ScheduleCreateRequest request) {
-        ScheduleResponse scheduleResponse = calendarService.updateSchedule(calendarId, scheduleId, request);
+        ScheduleResponse scheduleResponse = calendarService.updateSchedule(scheduleId, request);
         return BaseResponse.ok(scheduleResponse);
     }
 
@@ -140,10 +135,9 @@ public class CalendarController {
                     content = @Content(schema = @Schema(implementation = BaseResponse.class))
             )
     })
-    @DeleteMapping("/{calendarId}/schedules/{scheduleId}")
+    @DeleteMapping("/schedules/{scheduleId}")
     public BaseResponse<ScheduleDeleteResponse> deleteSchedule(
-            @PathVariable Long calendarId,
-            @PathVariable Long scheduleId) {
-        return BaseResponse.ok(calendarService.deleteSchedule(calendarId, scheduleId));
+            @PathVariable("scheduleId") Long scheduleId) {
+        return BaseResponse.ok(calendarService.deleteSchedule(scheduleId));
     }
 }

--- a/backend/src/main/java/com/kongdak/controller/DailyQuestionController.java
+++ b/backend/src/main/java/com/kongdak/controller/DailyQuestionController.java
@@ -27,28 +27,28 @@ import java.util.List;
 public class DailyQuestionController {
     private final DailyQuestionService dailyQuestionService;
 
-    @GetMapping
-    @Operation(summary = "오늘의 질문 조회", description = "오늘의 데일리 질문을 조회합니다.")
+    @GetMapping("/current")
+    @Operation(summary = "오늘의 질문과 답변 조회", description = "현재 진행 중인 데일리 질문과 해당 질문에 대한 답변들을 함께 조회합니다.")
     @ApiResponse(responseCode = "200", description = "조회 성공",
             content = @Content(schema = @Schema(implementation = BaseResponse.class)))
-    public BaseResponse<DailyQuestionResponse> getDailyQuestion(
+    public BaseResponse<DailyQuestionWithAnswersResponse> getDailyQuestion(
             @Parameter(description = "인증된 사용자 ID", hidden = true)
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        return BaseResponse.ok(dailyQuestionService.getDailyQuestion(userDetails.getId()));
+        return BaseResponse.ok(dailyQuestionService.getDailyQuestionWithAnswers(userDetails.getId()));
     }
 
-    @Operation(summary = "답변 목록 조회", description = "특정 질문에 대한 답변 목록을 조회합니다.")
+    @Operation(summary = "질문 및 답변 상세 조회", description = "특정 질문에 대한 제목과 답변을 상세 조회합니다.")
     @ApiResponse(responseCode = "200", description = "조회 성공",
             content = @Content(schema = @Schema(implementation = BaseResponse.class)))
-    @GetMapping("/{questionId}/answers")
-    public BaseResponse<List<DailyAnswerResponse>> getAnswers(
+    @GetMapping("/{questionId}")
+    public BaseResponse<DailyQuestionWithAnswersResponse> getAnswers(
             @Parameter(description = "인증된 사용자 ID", hidden = true)
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @Parameter(description = "질문 ID", required = true)
             @PathVariable("questionId") Long questionId) {
         return BaseResponse.ok(
-                dailyQuestionService.getAnswers(userDetails.getId(), questionId)
+                dailyQuestionService.getDailyQuestionDetail(userDetails.getId(), questionId)
         );
     }
 
@@ -64,6 +64,17 @@ public class DailyQuestionController {
             @Parameter(description = "답변 내용")
             @RequestBody @Valid DailyAnswerRequest request) {
         return BaseResponse.created(dailyQuestionService.createAnswer(userDetails.getId(), questionId, request));
+    }
+
+    @Operation(summary = "질문 히스토리 조회", description = "첫 번째 질문부터 현재 진행 중인 질문까지의 모든 질문 목록을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "조회 성공",
+            content = @Content(schema = @Schema(implementation = BaseResponse.class)))
+    @GetMapping("/history")
+    public BaseResponse<List<DailyQuestionListResponse>> getAllQuestions(
+            @Parameter(description = "인증된 사용자 ID", hidden = true)
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        return BaseResponse.ok(dailyQuestionService.getAllQuestions(userDetails.getId()));
     }
 
     @PatchMapping("/{questionId}/answers/{answerId}/emoji")
@@ -108,7 +119,7 @@ public class DailyQuestionController {
             @Parameter(description = "질문 ID", required = true)
             @PathVariable("questionId") Long questionId,
             @Parameter(description = "댓글 ID", required = true)
-            @PathVariable Long replyId) {
+            @PathVariable("replyId") Long replyId) {
 
         return BaseResponse.ok(dailyQuestionService.deleteReply(userDetails.getId(), questionId, replyId));
     }

--- a/backend/src/main/java/com/kongdak/controller/dto/response/DailyAnswerResponse.java
+++ b/backend/src/main/java/com/kongdak/controller/dto/response/DailyAnswerResponse.java
@@ -17,14 +17,18 @@ public record DailyAnswerResponse(
         String content,
 
         @Schema(description = "작성 시간", example = "2024-01-10T12:00:00")
-        LocalDateTime createdAt
+        LocalDateTime createdAt,
+
+        @Schema(description = "현재 사용자가 볼 수 있는지 여부", example = "true")
+        boolean isVisible
 ) {
-    public static DailyAnswerResponse from(DailyAnswer answer) {
+    public static DailyAnswerResponse from(DailyAnswer answer, boolean bothAnswered, Long currentMemberId) {
         return new DailyAnswerResponse(
                 answer.getId(),
                 answer.getMember().getId(),
                 answer.getContent(),
-                answer.getCreatedAt()
+                answer.getCreatedAt(),
+                bothAnswered || answer.getMember().getId().equals(currentMemberId)
         );
     }
 }

--- a/backend/src/main/java/com/kongdak/controller/dto/response/DailyQuestionListResponse.java
+++ b/backend/src/main/java/com/kongdak/controller/dto/response/DailyQuestionListResponse.java
@@ -1,0 +1,20 @@
+package com.kongdak.controller.dto.response;
+
+import com.kongdak.domain.dailyquestion.DailyQuestion;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "데일리 질문 목록 응답")
+public record DailyQuestionListResponse(
+        @Schema(description = "질문 ID", example = "1")
+        Long questionId,
+
+        @Schema(description = "질문 제목", example = "오늘 가장 행복했던 순간은?")
+        String title
+) {
+    public static DailyQuestionListResponse from(DailyQuestion question) {
+        return new DailyQuestionListResponse(
+                question.getId(),
+                question.getTitle()
+        );
+    }
+}

--- a/backend/src/main/java/com/kongdak/controller/dto/response/DailyQuestionWithAnswersResponse.java
+++ b/backend/src/main/java/com/kongdak/controller/dto/response/DailyQuestionWithAnswersResponse.java
@@ -1,0 +1,31 @@
+package com.kongdak.controller.dto.response;
+
+import com.kongdak.domain.dailyquestion.DailyAnswer;
+import com.kongdak.domain.dailyquestion.DailyQuestion;
+import lombok.Builder;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Builder
+public record DailyQuestionWithAnswersResponse(
+        Long questionId,
+        String title,
+        List<DailyAnswerResponse> answers,
+        boolean bothAnswered
+) {
+    public static DailyQuestionWithAnswersResponse of(
+            DailyQuestion question,
+            List<DailyAnswer> answers,
+            Long currentMemberId
+    ) {
+        return new DailyQuestionWithAnswersResponse(
+                question.getId(),
+                question.getTitle(),
+                answers.stream()
+                        .map(answer -> DailyAnswerResponse.from(answer, answers.size() == 2, currentMemberId))
+                        .collect(Collectors.toList()),
+                answers.size() == 2
+        );
+    }
+}

--- a/backend/src/main/java/com/kongdak/domain/calendar/CalendarService.java
+++ b/backend/src/main/java/com/kongdak/domain/calendar/CalendarService.java
@@ -56,6 +56,7 @@ public class CalendarService {
     // 일정 상세 조회
     public ScheduleDetailResponse getScheduleDetail(Long calendarId, Long scheduleId) {
         Calendar calendar = findCalendarById(calendarId);
+        Calendar calendar = getCurrentCalendar();
         Schedule schedule = findScheduleById(scheduleId);
 
         validateCalendarAccess(calendar);

--- a/backend/src/main/java/com/kongdak/domain/calendar/CalendarService.java
+++ b/backend/src/main/java/com/kongdak/domain/calendar/CalendarService.java
@@ -11,7 +11,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.YearMonth;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -39,7 +41,9 @@ public class CalendarService {
     }
 
     // 월별 일정 조회
-    public MonthlyScheduleResponse getMonthlySchedules(Long calendarId, LocalDateTime dateTime) {
+    public MonthlyScheduleResponse getMonthlySchedules(YearMonth dateTime) {
+
+        Long calendarId = getCurrentCalendar().getId();
         Calendar calendar = findCalendarById(calendarId);
 
         validateCalendarAccess(calendar);
@@ -60,7 +64,7 @@ public class CalendarService {
         Schedule schedule = findScheduleById(scheduleId);
 
         validateCalendarAccess(calendar);
-        validateScheduleForCalendar(schedule, calendarId);
+        validateScheduleForCalendar(schedule, calendar.getId());
 
         return ScheduleDetailResponse.from(schedule);
     }
@@ -77,11 +81,11 @@ public class CalendarService {
     }
 
     // 일별 일정 조회
-    public List<ScheduleResponse> getDailySchedules(Long calendarId, LocalDateTime dateTime) {
-        Calendar calendar = findCalendarById(calendarId);
+    public List<ScheduleResponse> getDailySchedules(LocalDate date) {
+        Calendar calendar = getCurrentCalendar();
         validateCalendarAccess(calendar);
 
-        return scheduleRepository.findDailySchedules(calendarId, dateTime.toLocalDate())
+        return scheduleRepository.findDailySchedules(calendar.getId(), date)
                 .stream()
                 .map(ScheduleResponse::from)
                 .collect(Collectors.toList());
@@ -89,10 +93,10 @@ public class CalendarService {
 
     // 일정 생성
     @Transactional
-    public ScheduleResponse createSchedule(Long calendarId, ScheduleCreateRequest request) {
+    public ScheduleResponse createSchedule(ScheduleCreateRequest request) {
         request.validate();
 
-        Calendar calendar = findCalendarById(calendarId);
+        Calendar calendar = getCurrentCalendar();
         Member currentMember = memberService.getCurrentMember();
 
         validateCalendarAccess(calendar);
@@ -114,15 +118,15 @@ public class CalendarService {
 
     // 일정 수정
     @Transactional
-    public ScheduleResponse updateSchedule(Long calendarId, Long scheduleId, ScheduleCreateRequest request) {
+    public ScheduleResponse updateSchedule(Long scheduleId, ScheduleCreateRequest request) {
         request.validate(); // Record의 validate 메서드 호출
 
-        Calendar calendar = findCalendarById(calendarId);
+        Calendar calendar = getCurrentCalendar();
         Schedule schedule = findScheduleById(scheduleId);
 
         validateCalendarAccess(calendar);
         validateScheduleAccess(schedule);
-        validateScheduleForCalendar(schedule, calendarId);
+        validateScheduleForCalendar(schedule, calendar.getId());
 
         schedule.update(
                 request.title(),
@@ -138,8 +142,8 @@ public class CalendarService {
 
     // 일정 삭제
     @Transactional
-    public ScheduleDeleteResponse deleteSchedule(Long calendarId, Long scheduleId) {
-        Calendar calendar = findCalendarById(calendarId);
+    public ScheduleDeleteResponse deleteSchedule(Long scheduleId) {
+        Calendar calendar = getCurrentCalendar();
         Schedule schedule = findScheduleById(scheduleId);
 
         validateCalendarAccess(calendar);
@@ -151,7 +155,7 @@ public class CalendarService {
 
         return ScheduleDeleteResponse.of(
                 scheduleId,
-                calendarId,
+                calendar.getId(),
                 scheduleTitle,
                 LocalDateTime.now()
         );
@@ -201,6 +205,13 @@ public class CalendarService {
         if (!schedule.getCalendar().getId().equals(calendarId)) {
             throw new BusinessException(ErrorCode.SCHEDULE_NOT_FOUND);
         }
+    }
+
+    // 현재 사용자의 캘린더 조회
+    private Calendar getCurrentCalendar() {
+        Member currentMember = memberService.getCurrentMember();
+        return calendarRepository.findByCouple(currentMember.getCouple())
+                .orElseThrow(() -> new BusinessException(ErrorCode.CALENDAR_NOT_FOUND));
     }
 
 }

--- a/backend/src/main/java/com/kongdak/domain/calendar/CalendarService.java
+++ b/backend/src/main/java/com/kongdak/domain/calendar/CalendarService.java
@@ -54,8 +54,8 @@ public class CalendarService {
     }
 
     // 일정 상세 조회
-    public ScheduleDetailResponse getScheduleDetail(Long calendarId, Long scheduleId) {
-        Calendar calendar = findCalendarById(calendarId);
+    public ScheduleDetailResponse getScheduleDetail(Long scheduleId) {
+
         Calendar calendar = getCurrentCalendar();
         Schedule schedule = findScheduleById(scheduleId);
 

--- a/backend/src/main/java/com/kongdak/domain/dailyquestion/DailyAnswerRepository.java
+++ b/backend/src/main/java/com/kongdak/domain/dailyquestion/DailyAnswerRepository.java
@@ -16,18 +16,11 @@ public interface DailyAnswerRepository extends JpaRepository<DailyAnswer, Long> 
     Optional<DailyAnswer> findByQuestionIdAndMemberId(Long questionId, Long memberId);
 
     // 특정 멤버의 마지막 답변 조회
-    @Query("SELECT da FROM DailyAnswer da " +
-            "WHERE da.member.id = :memberId " +
-            "ORDER BY da.question.id DESC")
-    Optional<DailyAnswer> findLastAnswerByMemberId(@Param("memberId") Long memberId);
+    Optional<DailyAnswer> findFirstByMemberIdOrderByQuestionIdDesc(Long memberId);
 
-    // 특정 커플(두 멤버)의 답변 여부 확인
+
     @Query("SELECT COUNT(da) FROM DailyAnswer da " +
             "WHERE da.question.id = :questionId " +
-            "AND da.member.id IN (:member1Id, :member2Id)")
-    long countAnswersByQuestionAndMembers(
-            @Param("questionId") Long questionId,
-            @Param("member1Id") Long member1Id,
-            @Param("member2Id") Long member2Id
-    );
+            "AND da.member.couple.id = :coupleId")
+    long countByQuestionIdAndCoupleId(@Param("questionId")Long questionId, @Param("coupleId")Long coupleId);
 }

--- a/backend/src/main/java/com/kongdak/domain/dailyquestion/DailyQuestionRepository.java
+++ b/backend/src/main/java/com/kongdak/domain/dailyquestion/DailyQuestionRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -18,6 +18,11 @@ public interface DailyQuestionRepository extends JpaRepository<DailyQuestion, Lo
             "WHERE dq.id > :questionId " +
             "ORDER BY dq.id ASC")
     Optional<DailyQuestion> findNextQuestion(@Param("questionId") Long questionId);
+
+
+    Optional<DailyQuestion> findFirstByIdGreaterThanOrderByIdAsc(Long questionId);
+
+    List<DailyQuestion> findByIdLessThanEqualOrderByIdDesc(Long todayQuestionId);
 }
 
 

--- a/backend/src/main/java/com/kongdak/domain/dailyquestion/DailyQuestionService.java
+++ b/backend/src/main/java/com/kongdak/domain/dailyquestion/DailyQuestionService.java
@@ -40,7 +40,7 @@ public class DailyQuestionService {
 
         // 현재 회원의 마지막 답변 조회
         Optional<DailyAnswer> lastAnswer =
-                dailyAnswerRepository.findLastAnswerByMemberId(memberId);
+                dailyAnswerRepository.findFirstByMemberIdOrderByQuestionIdDesc(memberId);
         // 다음 질문 조회
         DailyQuestion nextQuestion;
         if (lastAnswer.isEmpty()) {
@@ -81,11 +81,16 @@ public class DailyQuestionService {
                 .build();
 
         DailyAnswer savedAnswer = dailyAnswerRepository.save(answer);
-        return DailyAnswerResponse.from(savedAnswer);
+
+        // 현재 질문에 대한 전체 답변 수 확인
+        List<DailyAnswer> answers = dailyAnswerRepository.findByQuestionId(questionId);
+        boolean bothAnswered = answers.size() == 2;
+
+        return DailyAnswerResponse.from(savedAnswer, bothAnswered, memberId);
     }
 
     // 답변 조회 (커플 둘 다 답변했을 때만 상대방 답변 보이도록)
-    public List<DailyAnswerResponse> getAnswers(Long memberId, Long questionId) {
+    public DailyQuestionWithAnswersResponse getDailyQuestionDetail(Long memberId, Long questionId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
 
@@ -98,20 +103,21 @@ public class DailyQuestionService {
             throw new BusinessException(ErrorCode.COUPLE_NOT_FOUND);
         }
 
+        // 질문 조회
+        DailyQuestion question = dailyQuestionRepository.findById(questionId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.QUESTION_NOT_FOUND));
         List<DailyAnswer> answers = dailyAnswerRepository.findByQuestionId(questionId);
 
-        // 둘 다 답변했는지 확인
-        if (answers.size() == 2) {
-            return answers.stream()
-                    .map(DailyAnswerResponse::from)
-                    .collect(Collectors.toList());
-        }
+        boolean bothAnswered = answers.size() == 2;
 
-        // 한 명만 답변했을 경우 자신의 답변만 반환
-        return answers.stream()
-                .filter(answer -> answer.getMember().getId().equals(memberId))
-                .map(DailyAnswerResponse::from)
-                .collect(Collectors.toList());
+        return DailyQuestionWithAnswersResponse.builder()
+                .questionId(question.getId())
+                .title(question.getTitle())
+                .answers(answers.stream()
+                        .map(answer -> DailyAnswerResponse.from(answer, bothAnswered, memberId))
+                        .collect(Collectors.toList()))
+                .bothAnswered(bothAnswered)
+                .build();
     }
 
     // 이모지 반응 추가
@@ -179,4 +185,48 @@ public class DailyQuestionService {
 
         return response;
     }
+
+    public DailyQuestionWithAnswersResponse getDailyQuestionWithAnswers(Long memberId) {
+        // 현재 회원의 커플 정보 조회
+        Couple couple = coupleRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.COUPLE_NOT_FOUND));
+
+        // 마지막 답변 조회
+        Optional<DailyAnswer> lastAnswer = dailyAnswerRepository.findFirstByMemberIdOrderByQuestionIdDesc(memberId);
+
+        // 현재/다음 질문 결정
+        DailyQuestion question;
+        if (lastAnswer.isEmpty()) {
+            question = dailyQuestionRepository.findFirstByOrderByIdAsc()
+                    .orElseThrow(() -> new BusinessException(ErrorCode.QUESTION_NOT_FOUND));
+        } else {
+            DailyQuestion currentQuestion = lastAnswer.get().getQuestion();
+            long answerCount = dailyAnswerRepository.countByQuestionIdAndCoupleId(
+                    currentQuestion.getId(),
+                    couple.getId()
+            );
+
+            question = (answerCount < 2)
+                    ? currentQuestion
+                    : dailyQuestionRepository.findFirstByIdGreaterThanOrderByIdAsc(currentQuestion.getId())
+                    .orElseThrow(() -> new BusinessException(ErrorCode.QUESTION_NOT_FOUND));
+        }
+
+        // 질문에 대한 답변들 조회
+        List<DailyAnswer> answers = dailyAnswerRepository.findByQuestionId(question.getId());
+
+        return DailyQuestionWithAnswersResponse.of(question, answers, memberId);
+    }
+
+    public List<DailyQuestionListResponse> getAllQuestions(Long memberId) {
+        Long todayQuestionId = getDailyQuestion(memberId).questionId();
+
+        // Id 1번부터 todayQuestionId까지 가져오는 메서드
+        return dailyQuestionRepository.findByIdLessThanEqualOrderByIdDesc(todayQuestionId)
+                .stream()
+                .map(DailyQuestionListResponse::from)
+                .collect(Collectors.toList());
+    }
+
+
 }


### PR DESCRIPTION
## 변경사항
### 1. API 엔드포인트 구조 개선
#### 데일리 질문 API
- `/daily-questions` -> `/daily-questions/current` 엔드포인트 변경
  - 현재 진행 중인 질문과 답변을 함께 조회하도록 개선
- `/daily-questions/{questionId}/answers` -> `/daily-questions/{questionId}` 상세보기로 변경
  - 질문과 답변을 함께 조회하도록 응답 구조 개선
- `/daily-questions/history` 엔드포인트 추가
  - 첫 번째 질문부터 현재까지의 리스트 조회 기능 추가(id, title)

#### 캘린더 API
- 캘린더 ID를 URL에서 제거하고 현재 사용자의 캘린더를 자동으로 조회하도록 변경
- URL 구조 단순화 및 일관성 개선
  - `/{calendarId}/schedules/monthly` -> `/schedules/monthly`
  - `/{calendarId}/schedules/daily` -> `/schedules/daily`
  - `/{calendarId}/schedules/{scheduleId}` -> `/schedules/{scheduleId}`

### 2. 데이터 모델 및 응답 구조 개선
- `DailyAnswerResponse`에 `isVisible` 필드 추가
  - 커플 모두가 답변했거나 자신의 답변인 경우에만 볼 수 있도록 프론트엔드에서 제어하기 쉽게 도움
- `DailyQuestionWithAnswersResponse` 도입
  - 질문과 답변을 함께 조회할 수 있도록 응답 구조 개선
- `DailyQuestionListResponse` 추가
  - 질문 히스토리 조회를 위한 응답 구조 추가

### 3. Repository 메서드 최적화
- 메서드명 개선 및 명확화
  - `findLastAnswerByMemberId` -> `findFirstByMemberIdOrderByQuestionIdDesc`
  - `countAnswersByQuestionAndMembers` -> `countByQuestionIdAndCoupleId`
- 불필요한 쿼리 제거 및 성능 최적화

### 4. 기타 개선사항
- `JacksonConfig` 추가로 `LocalDateTime` deserialization 처리 개선
- Calendar 서비스 로직에서 현재 사용자의 캘린더를 조회하는 부분을 공통 메서드로 추출

## 테스트 완료 사항(Swagger)
- [x] 데일리 질문 API 엔드포인트 변경에 따른 기능 테스트
- [x] 캘린더 API 엔드포인트 변경에 따른 기능 테스트
- [x] 답변 조회 시 visibility 로직 테스트
- [x] 히스토리 조회 기능 테스트
- [x] LocalDateTime 파싱 테스트

## 해당 이슈
- Closes #61