### PR TITLE
데일리 질문, 다이어리 목록 조회 방식 변경, Soft Delete 구현

### DIFF
--- a/backend/src/main/java/com/kongdak/controller/DailyQuestionController.java
+++ b/backend/src/main/java/com/kongdak/controller/DailyQuestionController.java
@@ -66,6 +66,19 @@ public class DailyQuestionController {
         return BaseResponse.created(dailyQuestionService.createAnswer(userDetails.getId(), questionId, request));
     }
 
+    @Operation(summary = "댓글 조회", description = "데일리 질문의 댓글을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "조회 성공",
+            content = @Content(schema = @Schema(implementation = BaseResponse.class)))
+    @GetMapping("/{questionId}/replies")
+    public BaseResponse<List<AnswerReplyResponse>> getReplies(
+            @Parameter(description = "인증된 사용자 ID", hidden = true)
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Parameter(description = "질문 ID", required = true)
+            @PathVariable("questionId") Long questionId) {
+
+        return BaseResponse.ok(dailyQuestionService.getReplies(questionId));
+    }
+
     @Operation(summary = "질문 히스토리 조회", description = "첫 번째 질문부터 현재 진행 중인 질문까지의 모든 질문 목록을 조회합니다.")
     @ApiResponse(responseCode = "200", description = "조회 성공",
             content = @Content(schema = @Schema(implementation = BaseResponse.class)))

--- a/backend/src/main/java/com/kongdak/controller/DiaryController.java
+++ b/backend/src/main/java/com/kongdak/controller/DiaryController.java
@@ -14,10 +14,11 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.time.YearMonth;
 
 @RestController
 @RequestMapping("/diaries")
@@ -62,11 +63,10 @@ public class DiaryController {
     public BaseResponse<SearchDiaryResponse> searchDiaries(
             @Parameter(description = "인증된 사용자 ID", hidden = true)
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @Parameter(description = "페이징 정보")
-            @PageableDefault Pageable pageable
+            @Parameter(description = "조회할 년월", example = "2024-01")
+            @RequestParam("datetime") @DateTimeFormat(pattern = "yyyy-MM") YearMonth dateTime
     ) {
-        SearchDiaryResponse response = diaryService.searchDiaries(userDetails.getId(), pageable);
-        return BaseResponse.ok(response);
+        return BaseResponse.ok(diaryService.searchDiaries(userDetails.getId(), dateTime));
     }
 
     @Operation(summary = "다이어리 수정", description = "작성된 다이어리를 수정합니다.")

--- a/backend/src/main/java/com/kongdak/controller/dto/response/AnswerReplyResponse.java
+++ b/backend/src/main/java/com/kongdak/controller/dto/response/AnswerReplyResponse.java
@@ -1,0 +1,32 @@
+package com.kongdak.controller.dto.response;
+
+import com.kongdak.domain.dailyquestion.AnswerReply;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "답변 댓글 응답")
+@Builder
+public record AnswerReplyResponse(
+        @Schema(description = "댓글 ID", example = "1")
+        Long replyId,
+
+        @Schema(description = "댓글 작성자 ID", example = "1")
+        Long memberId,
+
+        @Schema(description = "댓글 내용", example = "좋은 생각이네요!")
+        String content,
+
+        @Schema(description = "댓글 작성 시간", example = "2024-01-19T18:30:00")
+        LocalDateTime createdAt
+) {
+    public static AnswerReplyResponse from(AnswerReply reply) {
+        return AnswerReplyResponse.builder()
+                .replyId(reply.getId())
+                .memberId(reply.getMember().getId())
+                .content(reply.getContent())
+                .createdAt(reply.getCreatedAt())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/kongdak/controller/dto/response/DailyAnswerResponse.java
+++ b/backend/src/main/java/com/kongdak/controller/dto/response/DailyAnswerResponse.java
@@ -1,11 +1,15 @@
 package com.kongdak.controller.dto.response;
 
+import com.kongdak.domain.dailyquestion.AnswerEmoji;
 import com.kongdak.domain.dailyquestion.DailyAnswer;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Schema(description = "데일리 답변 응답")
+
+
 public record DailyAnswerResponse(
         @Schema(description = "답변 ID", example = "1")
         Long answerId,
@@ -20,7 +24,10 @@ public record DailyAnswerResponse(
         LocalDateTime createdAt,
 
         @Schema(description = "현재 사용자가 볼 수 있는지 여부", example = "true")
-        boolean isVisible
+        boolean isVisible,
+
+        @Schema(description = "이모지", example = "true")
+        List<String> emoji
 ) {
     public static DailyAnswerResponse from(DailyAnswer answer, boolean bothAnswered, Long currentMemberId) {
         return new DailyAnswerResponse(
@@ -28,7 +35,11 @@ public record DailyAnswerResponse(
                 answer.getMember().getId(),
                 answer.getContent(),
                 answer.getCreatedAt(),
-                bothAnswered || answer.getMember().getId().equals(currentMemberId)
+                bothAnswered || answer.getMember().getId().equals(currentMemberId),
+                answer.getEmojis().stream().map(
+                        AnswerEmoji::getEmoji
+                ).toList()
         );
     }
+
 }

--- a/backend/src/main/java/com/kongdak/controller/dto/response/DailyQuestionWithAnswersResponse.java
+++ b/backend/src/main/java/com/kongdak/controller/dto/response/DailyQuestionWithAnswersResponse.java
@@ -12,12 +12,14 @@ public record DailyQuestionWithAnswersResponse(
         Long questionId,
         String title,
         List<DailyAnswerResponse> answers,
+        int replyCounts,
         boolean bothAnswered
 ) {
     public static DailyQuestionWithAnswersResponse of(
             DailyQuestion question,
             List<DailyAnswer> answers,
-            Long currentMemberId
+            Long currentMemberId,
+            int replyCounts
     ) {
         return new DailyQuestionWithAnswersResponse(
                 question.getId(),
@@ -25,6 +27,7 @@ public record DailyQuestionWithAnswersResponse(
                 answers.stream()
                         .map(answer -> DailyAnswerResponse.from(answer, answers.size() == 2, currentMemberId))
                         .collect(Collectors.toList()),
+                replyCounts,
                 answers.size() == 2
         );
     }

--- a/backend/src/main/java/com/kongdak/controller/dto/response/SearchDiaryResponse.java
+++ b/backend/src/main/java/com/kongdak/controller/dto/response/SearchDiaryResponse.java
@@ -9,25 +9,14 @@ import java.util.List;
 @Schema(description = "다이어리 검색 응답")
 public record SearchDiaryResponse(
         @Schema(description = "다이어리 목록")
-        List<DiaryListResponse> diaries,
+        List<DiaryListResponse> diaries
 
-        @Schema(description = "전체 페이지 수", example = "10")
-        int totalPages,
-
-        @Schema(description = "전체 항목 수", example = "100")
-        long totalElements,
-
-        @Schema(description = "다음 페이지 존재 여부", example = "true")
-        boolean hasNext
 ) {
-    public static SearchDiaryResponse from(Page<Diary> diaryPage) {
+    public static SearchDiaryResponse from(List<Diary> diaries) {
         return new SearchDiaryResponse(
-                diaryPage.getContent().stream()
+                diaries.stream()
                         .map(DiaryListResponse::from)
-                        .toList(),
-                diaryPage.getTotalPages(),
-                diaryPage.getTotalElements(),
-                diaryPage.hasNext()
+                        .toList()
         );
     }
 }

--- a/backend/src/main/java/com/kongdak/domain/BaseTimeEntity.java
+++ b/backend/src/main/java/com/kongdak/domain/BaseTimeEntity.java
@@ -4,6 +4,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
+import org.hibernate.annotations.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -11,9 +12,22 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import java.time.LocalDateTime;
 
 @MappedSuperclass
+@SQLDelete(sql = "UPDATE #{entityName} SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
+@SQLRestriction("deleted_at is null")  // 자동으로 where 조건 추가
 @EntityListeners(AuditingEntityListener.class)
 @Getter
 public class BaseTimeEntity {
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    public void delete() {
+        this.deletedAt = LocalDateTime.now();
+    }
+
+    public boolean isDeleted() {
+        return this.deletedAt != null;
+    }
 
     @CreatedDate
     @Column(updatable = false)

--- a/backend/src/main/java/com/kongdak/domain/calendar/CalendarService.java
+++ b/backend/src/main/java/com/kongdak/domain/calendar/CalendarService.java
@@ -3,6 +3,7 @@ package com.kongdak.domain.calendar;
 import com.kongdak.controller.dto.request.ScheduleCreateRequest;
 import com.kongdak.controller.dto.response.*;
 import com.kongdak.domain.couple.Couple;
+import com.kongdak.domain.couple.CoupleService;
 import com.kongdak.domain.member.Member;
 import com.kongdak.domain.member.MemberService;
 import com.kongdak.global.exception.BusinessException;
@@ -25,6 +26,7 @@ public class CalendarService {
     private final ScheduleRepository scheduleRepository;
     private final HolidayRepository holidayRepository;
     private final MemberService memberService;
+    private final CoupleService coupleService;  // 추가
 
     // 캘린더 생성 (커플 연결 시 자동 생성)
     @Transactional
@@ -195,6 +197,16 @@ public class CalendarService {
 
     private void validateScheduleAccess(Schedule schedule) {
         Member currentMember = memberService.getCurrentMember();
+
+        // SHARED 카테고리인 경우 커플 중 누구나 수정 가능
+        if (schedule.getCategory() == ScheduleCategory.SHARED) {
+
+            if (coupleService.isCoupleMember(currentMember, schedule.getCalendar().getCouple().getId())) {
+                return;
+            }
+            throw new BusinessException(ErrorCode.SCHEDULE_ACCESS_DENIED);
+        }
+
 
         if (!schedule.getCreator().equals(currentMember)) {
             throw new BusinessException(ErrorCode.SCHEDULE_ACCESS_DENIED);

--- a/backend/src/main/java/com/kongdak/domain/couple/CoupleService.java
+++ b/backend/src/main/java/com/kongdak/domain/couple/CoupleService.java
@@ -207,4 +207,10 @@ public class CoupleService {
             throw new BusinessException(ErrorCode.NOT_COUPLE_MEMBER);
         }
     }
+
+    public boolean isCoupleMember(Member currentMember, Long coupleId) {
+        return coupleRepository.findByMemberId(currentMember.getId()).orElseThrow(
+                () -> new BusinessException(ErrorCode.COUPLE_NOT_FOUND)
+        ).getId().equals(coupleId);
+    }
 }

--- a/backend/src/main/java/com/kongdak/domain/dailyquestion/AnswerReplyRepository.java
+++ b/backend/src/main/java/com/kongdak/domain/dailyquestion/AnswerReplyRepository.java
@@ -1,12 +1,19 @@
 package com.kongdak.domain.dailyquestion;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 @Repository
 public interface AnswerReplyRepository extends JpaRepository<AnswerReply, Long> {
+    // 질문에 달린 전체 댓글 수 조회
+    int countByQuestionId(Long questionId);
+
     // 특정 질문의 모든 댓글 조회
     List<AnswerReply> findByQuestionId(Long questionId);
+
+    List<AnswerReply> findByQuestionIdOrderByCreatedAtDesc(Long questionId);
 }

--- a/backend/src/main/java/com/kongdak/domain/dailyquestion/DailyAnswer.java
+++ b/backend/src/main/java/com/kongdak/domain/dailyquestion/DailyAnswer.java
@@ -8,6 +8,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+import java.util.ArrayList;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -28,6 +31,9 @@ public class DailyAnswer extends BaseTimeEntity {
 
     @Column(nullable = false)
     private String content;
+
+    @OneToMany(mappedBy = "answer", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<AnswerEmoji> emojis = new ArrayList<>();
 
     @Builder
     public DailyAnswer(DailyQuestion question, Member member, String content) {

--- a/backend/src/main/java/com/kongdak/domain/dailyquestion/DailyAnswerRepository.java
+++ b/backend/src/main/java/com/kongdak/domain/dailyquestion/DailyAnswerRepository.java
@@ -19,8 +19,15 @@ public interface DailyAnswerRepository extends JpaRepository<DailyAnswer, Long> 
     Optional<DailyAnswer> findFirstByMemberIdOrderByQuestionIdDesc(Long memberId);
 
 
+    // 답변 수 세기
     @Query("SELECT COUNT(da) FROM DailyAnswer da " +
             "WHERE da.question.id = :questionId " +
             "AND da.member.couple.id = :coupleId")
-    long countByQuestionIdAndCoupleId(@Param("questionId")Long questionId, @Param("coupleId")Long coupleId);
+    long countByQuestionIdAndCoupleId(@Param("questionId") Long questionId, @Param("coupleId") Long coupleId);
+
+    // 이모지 Fetch Join 하여 가져오기
+    @Query("SELECT DISTINCT a FROM DailyAnswer a " +
+            "LEFT JOIN FETCH a.emojis " +
+            "WHERE a.question.id = :questionId")
+    List<DailyAnswer> findByQuestionIdWithEmojis(@Param("questionId") Long questionId);
 }

--- a/backend/src/main/java/com/kongdak/domain/dailyquestion/DailyQuestionRepository.java
+++ b/backend/src/main/java/com/kongdak/domain/dailyquestion/DailyQuestionRepository.java
@@ -16,7 +16,8 @@ public interface DailyQuestionRepository extends JpaRepository<DailyQuestion, Lo
     // 특정 ID 이후의 다음 질문 조회
     @Query("SELECT dq FROM DailyQuestion dq " +
             "WHERE dq.id > :questionId " +
-            "ORDER BY dq.id ASC")
+            "ORDER BY dq.id ASC " +
+            "limit 1 ")
     Optional<DailyQuestion> findNextQuestion(@Param("questionId") Long questionId);
 
 

--- a/backend/src/main/java/com/kongdak/domain/dailyquestion/DailyQuestionService.java
+++ b/backend/src/main/java/com/kongdak/domain/dailyquestion/DailyQuestionService.java
@@ -107,7 +107,7 @@ public class DailyQuestionService {
         DailyQuestion question = dailyQuestionRepository.findById(questionId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.QUESTION_NOT_FOUND));
         List<DailyAnswer> answers = dailyAnswerRepository.findByQuestionId(questionId);
-
+        int replyCounts = answerReplyRepository.countByQuestionId(questionId);
         boolean bothAnswered = answers.size() == 2;
 
         return DailyQuestionWithAnswersResponse.builder()
@@ -117,6 +117,7 @@ public class DailyQuestionService {
                         .map(answer -> DailyAnswerResponse.from(answer, bothAnswered, memberId))
                         .collect(Collectors.toList()))
                 .bothAnswered(bothAnswered)
+                .replyCounts(replyCounts)
                 .build();
     }
 
@@ -214,8 +215,8 @@ public class DailyQuestionService {
 
         // 질문에 대한 답변들 조회
         List<DailyAnswer> answers = dailyAnswerRepository.findByQuestionId(question.getId());
-
-        return DailyQuestionWithAnswersResponse.of(question, answers, memberId);
+        int replyCounts = answerReplyRepository.countByQuestionId(question.getId());
+        return DailyQuestionWithAnswersResponse.of(question, answers, memberId, replyCounts);
     }
 
     public List<DailyQuestionListResponse> getAllQuestions(Long memberId) {
@@ -229,4 +230,12 @@ public class DailyQuestionService {
     }
 
 
+    public List<AnswerReplyResponse> getReplies(Long questionId) {
+
+        List<AnswerReply> replies = answerReplyRepository.findByQuestionIdOrderByCreatedAtDesc(questionId);
+
+        return replies.stream()
+                .map(AnswerReplyResponse::from)
+                .collect(Collectors.toList());
+    }
 }

--- a/backend/src/main/java/com/kongdak/domain/diary/DiaryRepository.java
+++ b/backend/src/main/java/com/kongdak/domain/diary/DiaryRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -46,4 +47,14 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
 
     // 특정 날짜의 일기 조회
     Optional<Diary> findByCoupleIdAndDiaryDate(Long coupleId, LocalDate diaryDate);
+
+    @Query("SELECT d FROM Diary d WHERE d.couple.id = :coupleId " +
+            "AND FUNCTION('YEAR', d.diaryDate) = :year " +
+            "AND FUNCTION('MONTH', d.diaryDate) = :month " +
+            "ORDER BY d.diaryDate ASC")
+    List<Diary> findMonthlyDiaries(
+            @Param("coupleId") Long coupleId,
+            @Param("year") int year,
+            @Param("month")int month)
+            ;
 }

--- a/backend/src/main/java/com/kongdak/domain/diary/DiaryService.java
+++ b/backend/src/main/java/com/kongdak/domain/diary/DiaryService.java
@@ -20,6 +20,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.YearMonth;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -170,9 +171,11 @@ public class DiaryService {
         return DiaryDetailResponse.from(diary);
     }
 
-    public SearchDiaryResponse searchDiaries(Long memberId, Pageable pageable) {
+    public SearchDiaryResponse searchDiaries(Long memberId, YearMonth dateTime) {
         Couple couple = getCoupleByMemberId(memberId);
-        Page<Diary> diaries = diaryRepository.findAllByCoupleIdOrderByDiaryDateDesc(couple.getId(), pageable);
+        int year = dateTime.getYear();
+        int month = dateTime.getMonthValue();
+        List<Diary> diaries = diaryRepository.findMonthlyDiaries(couple.getId(), year, month);
         return SearchDiaryResponse.from(diaries);
     }
 


### PR DESCRIPTION
# 비즈니스 로직 수정
- [x] 데일리 질문 댓글 조회 기능 추가
- [x] getDailyQuestion 오류 수정
- [x] 다이어리 목록 조회 시 페이징에서 월별 목록 조회로 변경
- [x] 질문 및 답변 상세조회에 답글 수 추가
- [x] 데일리 질문 상세 조회시 이모지 함께 조회
- [x] 함께 하는 일정(SHARED)은 커플 누구나 수정, 삭제 할 수 있게 함
- [x] 모든 엔티티에 대해서 삭제는 Soft Delete로 구현

## Key Changes
1. **Calendar Service**
   - SHARED 카테고리 일정에 대해 커플 양쪽 모두 수정/삭제 권한 부여

2. **Soft Delete 구현**
   - BaseTimeEntity에 Soft Delete 기능 추가
   - @SQLDelete와 @SQLRestriction 사용

3. **데일리 질문 기능 개선**
   - 댓글 조회 기능 추가
   - 답변에 이모지 기능 추가
   - 답글 수 표시 추가

4. **다이어리 조회 방식 변경**
   - 페이징 방식에서 월별 목록 조회로 변경
   - 월 단위로 다이어리 조회하도록 개선