### PR TITLE
JWT 토큰 관련 에러 커스텀 및 BaseResponse 적용

### DIFF
--- a/backend/src/main/java/com/kongdak/config/SecurityConfig.java
+++ b/backend/src/main/java/com/kongdak/config/SecurityConfig.java
@@ -45,7 +45,6 @@ public class SecurityConfig {
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .authorizeHttpRequests(auth -> auth
-//                        .requestMatchers("/api/auth/**", "/api/oauth2/**", "/oauth2/**").permitAll()
                         .requestMatchers("/auth/**", "/api/**", "/oauth2/**").permitAll()
                         // Swagger UI 관련 경로 허용
                         .requestMatchers(
@@ -56,7 +55,6 @@ public class SecurityConfig {
                         ).permitAll()
                         .anyRequest().authenticated()
                 );
-
         return http.build();
     }
 

--- a/backend/src/main/java/com/kongdak/global/security/jwt/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/kongdak/global/security/jwt/JwtAuthenticationFilter.java
@@ -1,39 +1,83 @@
 package com.kongdak.global.security.jwt;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kongdak.global.exception.BusinessException;
+import com.kongdak.global.exception.ErrorCode;
+import com.kongdak.global.response.BaseResponse;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 @Component
 @Slf4j
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtTokenProvider jwtTokenProvider;
+    private final ObjectMapper objectMapper;
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
 
         try {
             String token = extractTokenFromRequest(request);
-
-            if (token != null && jwtTokenProvider.validateToken(token)) {
-                Authentication authentication = jwtTokenProvider.getAuthentication(token);
-                SecurityContextHolder.getContext().setAuthentication(authentication);
+            
+            if(token == null) {
+                handleAuthenticationError(response, ErrorCode.UNAUTHORIZED_ACCESS);
+                return;
             }
-        } catch (Exception e) {
+            jwtTokenProvider.validateToken(token);
+            Authentication authentication = jwtTokenProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            filterChain.doFilter(request, response);    
+        } catch (BusinessException e) {
+            log.error("Authentication error occurred: {}", e.getMessage());
             SecurityContextHolder.clearContext();
-            log.error("Could not set user authentication in security context", e);
+            handleAuthenticationError(response, e.getErrorCode());
+        } catch (Exception e) {
+            log.error("Unexpected error occurred during authentication: ", e);
+            SecurityContextHolder.clearContext();
+            handleAuthenticationError(response, ErrorCode.INTERNAL_SERVER_ERROR);
         }
 
-        filterChain.doFilter(request, response);
+        
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getRequestURI();
+        boolean shouldNotFilter = path.equals("/api/login") ||
+                path.startsWith("/auth/") ||
+                path.startsWith("/oauth2/") ||
+                path.startsWith("/api/auth") ||
+                path.startsWith("/v3/api-docs") ||
+                path.startsWith("/swagger-ui/");
+
+        System.out.println("Path: " + path + ", shouldNotFilter = " + shouldNotFilter);
+        return shouldNotFilter;
+    }
+
+    private void handleAuthenticationError(HttpServletResponse response, ErrorCode errorCode) throws IOException {
+        response.setStatus(errorCode.getStatus());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+
+        BaseResponse<?> errorResponse = BaseResponse.error(
+                errorCode.getStatus(),
+                errorCode.getCode(),
+                errorCode.getMessage()
+        );
+
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
     }
 
     private String extractTokenFromRequest(HttpServletRequest request) {

--- a/backend/src/main/java/com/kongdak/global/security/jwt/JwtTokenProvider.java
+++ b/backend/src/main/java/com/kongdak/global/security/jwt/JwtTokenProvider.java
@@ -1,7 +1,10 @@
 package com.kongdak.global.security.jwt;
 
+import com.kongdak.global.exception.BusinessException;
+import com.kongdak.global.exception.ErrorCode;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
 
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -152,16 +155,19 @@ public class JwtTokenProvider {
                     .build()
                     .parseClaimsJws(token);
             return true;
-        } catch (SecurityException | MalformedJwtException e) {
+        } catch (SecurityException | MalformedJwtException | SignatureException e) {
             log.error("Invalid JWT signature: {}", e.getMessage());
+            throw new BusinessException(ErrorCode.INVALID_ACCESS_TOKEN);
         } catch (ExpiredJwtException e) {
             log.error("JWT token is expired: {}", e.getMessage());
+            throw new BusinessException(ErrorCode.EXPIRED_TOKEN);
         } catch (UnsupportedJwtException e) {
             log.error("JWT token is unsupported: {}", e.getMessage());
+            throw new BusinessException(ErrorCode.INVALID_ACCESS_TOKEN);
         } catch (IllegalArgumentException e) {
             log.error("JWT claims string is empty: {}", e.getMessage());
+            throw new BusinessException(ErrorCode.INVALID_ACCESS_TOKEN);
         }
-        return false;
     }
 
     // Access Token과 Refresh Token을 함께 재발급

--- a/backend/src/main/java/com/kongdak/global/security/jwt/OAuth2SuccessHandler.java
+++ b/backend/src/main/java/com/kongdak/global/security/jwt/OAuth2SuccessHandler.java
@@ -1,6 +1,7 @@
 package com.kongdak.global.security.jwt;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kongdak.global.response.BaseResponse;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -35,6 +36,15 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
         refreshTokenRepository.save(email, refreshToken,
                 jwtTokenProvider.getRefreshTokenValidityInMilliseconds());
+
+        // BaseResponse 형식으로 응답 생성
+        BaseResponse<TokenResponse> baseResponse = BaseResponse.ok(
+                TokenResponse.builder()
+                        .accessToken(accessToken)
+                        .refreshToken(refreshToken)
+                        .provider(provider)
+                        .build()
+        );
         // Response 설정
         response.setContentType("application/json;charset=UTF-8");
         response.setStatus(HttpServletResponse.SC_OK);
@@ -45,7 +55,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
                 .refreshToken(refreshToken)
                 .provider(provider)
                 .build();
-        response.getWriter().write(objectMapper.writeValueAsString(tokenResponse));
+        response.getWriter().write(objectMapper.writeValueAsString(baseResponse));
 
         log.info("OAuth2 Login Success: {}", String.valueOf(email));
     }


### PR DESCRIPTION
# JWT 토큰 관련 에러 커스텀 및 BaseResponse 적용

## 변경사항
- JWT 토큰 관련 에러 응답을 BaseResponse 형식으로 통일
- 토큰 검증 로직 개선 및 에러 처리 강화
- OAuth2 로그인 성공 응답도 BaseResponse 형태로 변경

## 상세 내용
### SecurityConfig.java
- 불필요한 주석 제거
- API 엔드포인트 접근 권한 정리

### JwtAuthenticationFilter.java
- 토큰 부재 시 에러 처리 로직 추가
- BusinessException 처리 로직 추가
- 에러 응답 포맷을 BaseResponse로 통일
- 인증 제외 경로 설정 개선

### JwtTokenProvider.java
- 토큰 검증 시 발생하는 예외들에 대한 구체적인 에러 메시지 추가
- BusinessException을 활용한 커스텀 에러 처리 구현

### OAuth2SuccessHandler.java
- 로그인 성공 응답을 BaseResponse 형식으로 변경
- 응답 구조 개선

## 관련 이슈
- Closes #86

