### PR TITLE
swagger 관련 엔드포인트 수정

### DIFF
--- a/backend/src/main/java/com/kongdak/global/security/jwt/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/kongdak/global/security/jwt/JwtAuthenticationFilter.java
@@ -56,11 +56,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected boolean shouldNotFilter(HttpServletRequest request) {
         String path = request.getRequestURI();
         boolean shouldNotFilter = path.equals("/api/login") ||
-                path.startsWith("/auth/") ||
                 path.startsWith("/oauth2/") ||
                 path.startsWith("/api/auth") ||
-                path.startsWith("/v3/api-docs") ||
-                path.startsWith("/swagger-ui/");
+                path.startsWith("/api/v3/api-docs") ||
+                path.startsWith("/api/swagger-ui/");
 
         System.out.println("Path: " + path + ", shouldNotFilter = " + shouldNotFilter);
         return shouldNotFilter;


### PR DESCRIPTION
- "/v3/api-docs" 와 "/swagger-ui/")는 모두 /api가 앞에 붙어야 하는 경로이므로 수정한다.