### PR TITLE
카카오 로그인 SDK로 전환

### DIFF
--- a/backend/src/main/java/com/kongdak/config/SecurityConfig.java
+++ b/backend/src/main/java/com/kongdak/config/SecurityConfig.java
@@ -37,12 +37,12 @@ public class SecurityConfig {
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
-                .oauth2Login(oauth2 -> oauth2
-                        .successHandler(oAuth2SuccessHandler)
-                        .userInfoEndpoint(userInfo -> userInfo
-                                .userService(customOAuth2UserService)
-                        )
-                )
+//                .oauth2Login(oauth2 -> oauth2
+//                        .successHandler(oAuth2SuccessHandler)
+//                        .userInfoEndpoint(userInfo -> userInfo
+//                                .userService(customOAuth2UserService)
+//                        )
+//                ) // SDK 연결로 인해 customOAuth2UserSerivce 를 사용하지 않도록 한다.
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/auth/**", "/api/**", "/oauth2/**").permitAll()

--- a/backend/src/main/java/com/kongdak/controller/AuthController.java
+++ b/backend/src/main/java/com/kongdak/controller/AuthController.java
@@ -1,14 +1,16 @@
 package com.kongdak.controller;
 
+import com.kongdak.controller.dto.request.SocialLoginRequest;
 import com.kongdak.controller.dto.request.TokenRefreshRequest;
 import com.kongdak.controller.dto.response.TokenRefreshResponse;
 import com.kongdak.global.exception.BusinessException;
 import com.kongdak.global.exception.ErrorCode;
 import com.kongdak.global.response.BaseResponse;
 import com.kongdak.global.security.jwt.CustomOAuth2UserService;
-import com.kongdak.global.security.jwt.JwtTokenProvider;
 import com.kongdak.global.security.jwt.RefreshTokenRepository;
 import com.kongdak.global.security.jwt.TokenPairResponse;
+import com.kongdak.global.security.jwt.sdk.SimpleJwtTokenProvider;
+import com.kongdak.global.security.jwt.sdk.SocialLoginService;
 import io.jsonwebtoken.Claims;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -18,11 +20,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.oauth2.core.user.OAuth2User;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/auth")
@@ -30,9 +28,23 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 @Tag(name = "인증", description = "인증 관련 API")
 public class AuthController {
-    private final JwtTokenProvider jwtTokenProvider;
+    private final SimpleJwtTokenProvider simpleJwtTokenProvider;
+    private final SocialLoginService socialLoginService;
     private final CustomOAuth2UserService customOAuth2UserService;
     private final RefreshTokenRepository refreshTokenRepository;
+
+    @Operation(summary = "소셜 로그인", description = "소셜 액세스 토큰으로 로그인합니다.")
+    @PostMapping("/login/{provider}")
+    public BaseResponse<TokenRefreshResponse> socialLogin(
+            @PathVariable String provider,
+            @RequestBody SocialLoginRequest request) {
+        TokenPairResponse tokenPair = socialLoginService.socialLogin(request.accessToken(), provider);
+
+        return BaseResponse.ok(TokenRefreshResponse.builder()
+                .accessToken(tokenPair.accessToken())
+                .refreshToken(tokenPair.refreshToken())
+                .build());
+    }
 
     @Operation(
             summary = "토큰 갱신",
@@ -55,45 +67,36 @@ public class AuthController {
     public BaseResponse<TokenRefreshResponse> refreshToken(@RequestBody TokenRefreshRequest request) {
         log.info("Received refresh token: {}", request.refreshToken());
         // RefreshToken 검증
-        if (!jwtTokenProvider.validateToken(request.refreshToken())) {
+        if (!simpleJwtTokenProvider.validateToken(request.refreshToken())) {
             log.error("Token validation failed");
             throw new BusinessException(ErrorCode.INVALID_REFRESH_TOKEN);
         }
 
         // 토큰에서 이메일 추출
-        Claims claims = jwtTokenProvider.parseClaims(request.refreshToken());
+        Claims claims = simpleJwtTokenProvider.parseClaims(request.refreshToken());
         String email = claims.getSubject();
         log.info("Email from token: {}", email);
 
         // Redis에 저장된 RefreshToken 확인
         String savedToken = refreshTokenRepository.findByEmail(email)
                 .orElseThrow(() -> {
-                    log.error("No refresh token found in Redis for email: {}", email);
-                return new BusinessException(ErrorCode.INVALID_REFRESH_TOKEN);
+                    return new BusinessException(ErrorCode.INVALID_REFRESH_TOKEN);
                 });
 
-        log.info("Token from Redis: {}", savedToken);
         if (!savedToken.equals(request.refreshToken())) {
-            log.error("Tokens do not match. Stored: {}, Received: {}",
-                    savedToken.substring(0, 10) + "...",
-                    request.refreshToken().substring(0, 10) + "...");
             throw new BusinessException(ErrorCode.INVALID_REFRESH_TOKEN);
         }
 
-        // CustomOAuth2UserService를 통해 OAuth2User 정보 가져오기
-        OAuth2User oAuth2User = customOAuth2UserService.loadUserByEmail(email);
         // 새로운 토큰 발급
-        TokenPairResponse tokens = jwtTokenProvider.reissueTokens(request.refreshToken());
+        TokenPairResponse tokens = simpleJwtTokenProvider.reissueTokens(request.refreshToken());
 
         // 새로운 RefreshToken을 Redis에 저장
         refreshTokenRepository.save(email, tokens.refreshToken(),
-                jwtTokenProvider.getRefreshTokenValidityInMilliseconds());
+                simpleJwtTokenProvider.getRefreshTokenValidityInMilliseconds());
 
-        TokenRefreshResponse response = TokenRefreshResponse.builder()
+        return BaseResponse.ok(TokenRefreshResponse.builder()
                 .accessToken(tokens.accessToken())
                 .refreshToken(tokens.refreshToken())
-                .build();
-
-        return BaseResponse.ok(response);
+                .build());
     }
 }

--- a/backend/src/main/java/com/kongdak/controller/dto/request/SocialLoginRequest.java
+++ b/backend/src/main/java/com/kongdak/controller/dto/request/SocialLoginRequest.java
@@ -1,0 +1,6 @@
+package com.kongdak.controller.dto.request;
+
+public record SocialLoginRequest(
+        String accessToken
+) {
+}

--- a/backend/src/main/java/com/kongdak/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/kongdak/global/exception/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
 
     // OAUTH2.0 관련 예외
     INVALID_PROVIDER(400, "O001", "옳지 않은 PROVIDER 입니다."),
+    INVALID_SOCIAL_TOKEN(400, "O002", "옳지않은 소셜 토큰입니다."),
 
     // Couple 관련 예외
     COUPLE_NOT_FOUND(404, "C001", "커플을 찾을 수 없습니다"),

--- a/backend/src/main/java/com/kongdak/global/security/jwt/sdk/SimpleJwtTokenProvider.java
+++ b/backend/src/main/java/com/kongdak/global/security/jwt/sdk/SimpleJwtTokenProvider.java
@@ -1,0 +1,162 @@
+package com.kongdak.global.security.jwt.sdk;
+
+import com.kongdak.domain.member.Member;
+import com.kongdak.global.exception.BusinessException;
+import com.kongdak.global.exception.ErrorCode;
+import com.kongdak.global.security.jwt.CustomUserDetails;
+import com.kongdak.global.security.jwt.TokenPairResponse;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Service;
+
+import java.security.Key;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.stream.Collectors;
+
+@Service
+@Slf4j
+public class SimpleJwtTokenProvider {
+    private final Key key;
+    private final long accessTokenValidityInMilliseconds;
+    @Getter
+    private final long refreshTokenValidityInMilliseconds;
+
+    public SimpleJwtTokenProvider(
+            @Value("${spring.jwt.secret}") String secretKey,
+            @Value("${spring.jwt.access-token-validity}") long accessTokenValidityInSeconds,
+            @Value("${spring.jwt.refresh-token-validity}") long refreshTokenValidityInSeconds) {
+        this.key = Keys.secretKeyFor(SignatureAlgorithm.HS256);
+        this.accessTokenValidityInMilliseconds = accessTokenValidityInSeconds * 1000;
+        this.refreshTokenValidityInMilliseconds = refreshTokenValidityInSeconds * 1000;
+    }
+
+    public TokenPairResponse createTokenPair(Member member) {
+        String accessToken = createAccessToken(member);
+        String refreshToken = createRefreshToken(member.getEmail());
+
+        return new TokenPairResponse(accessToken, refreshToken);
+    }
+
+    private String createAccessToken(Member member) {
+        Date now = new Date();
+        Date validity = new Date(now.getTime() + accessTokenValidityInMilliseconds);
+
+        return Jwts.builder()
+                .setSubject(member.getEmail())
+                .claim("auth", "ROLE_USER")
+                .setIssuedAt(now)
+                .setExpiration(validity)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    private String createRefreshToken(String email) {
+        Date now = new Date();
+        Date validity = new Date(now.getTime() + refreshTokenValidityInMilliseconds);
+
+        return Jwts.builder()
+                .setSubject(email)
+                .setIssuedAt(now)
+                .setExpiration(validity)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token);
+            return true;
+        } catch (SecurityException | MalformedJwtException | SignatureException e) {
+            log.error("Invalid JWT signature: {}", e.getMessage());
+            throw new BusinessException(ErrorCode.INVALID_ACCESS_TOKEN);
+        } catch (ExpiredJwtException e) {
+            log.error("JWT token is expired: {}", e.getMessage());
+            throw new BusinessException(ErrorCode.EXPIRED_TOKEN);
+        } catch (UnsupportedJwtException e) {
+            log.error("JWT token is unsupported: {}", e.getMessage());
+            throw new BusinessException(ErrorCode.INVALID_ACCESS_TOKEN);
+        } catch (IllegalArgumentException e) {
+            log.error("JWT claims string is empty: {}", e.getMessage());
+            throw new BusinessException(ErrorCode.INVALID_ACCESS_TOKEN);
+        }
+    }
+
+    // Claims 파싱
+    public Claims parseClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+    // 토큰에서 Authentication 객체 추출
+    public Authentication getAuthentication(String token) {
+        Claims claims = parseClaims(token);
+
+        log.info("Token claims: {}", claims);
+        log.info("id claim value: {}", claims.get("id"));
+        log.info("subject value: {}", claims.getSubject());
+        log.info("auth claim value: {}", claims.get("auth"));
+
+        Collection<? extends GrantedAuthority> authorities =
+                Arrays.stream(claims.get("auth").toString().split(","))
+                        .map(SimpleGrantedAuthority::new)
+                        .collect(Collectors.toList());
+
+        CustomUserDetails principal = CustomUserDetails.builder()
+                .id(Long.parseLong(claims.get("id").toString()))
+                .email(claims.getSubject())
+                .authorities(authorities)
+                .build();
+
+        return new UsernamePasswordAuthenticationToken(principal, token, authorities);
+    }
+
+    public TokenPairResponse reissueTokens(String oldRefreshToken) {
+        // Refresh Token 검증
+        if (!validateToken(oldRefreshToken)) {
+            throw new BusinessException(ErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        // Refresh Token에서 사용자 정보(email) 추출
+        Claims claims = parseClaims(oldRefreshToken);
+        String email = claims.getSubject();
+
+        // 3. 새로운 토큰 쌍 생성
+        Date now = new Date();
+        Date accessTokenValidity = new Date(now.getTime() + accessTokenValidityInMilliseconds);
+        Date refreshTokenValidity = new Date(now.getTime() + refreshTokenValidityInMilliseconds);
+
+        // 새로운 Access Token 생성
+        String newAccessToken = Jwts.builder()
+                .setSubject(email)
+                .claim("auth", "ROLE_USER")
+                .setIssuedAt(now)
+                .setExpiration(accessTokenValidity)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+
+        // 새로운 Refresh Token 생성
+        String newRefreshToken = Jwts.builder()
+                .setSubject(email)
+                .setIssuedAt(now)
+                .setExpiration(refreshTokenValidity)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+
+        return new TokenPairResponse((newAccessToken), newRefreshToken);
+    }
+}

--- a/backend/src/main/java/com/kongdak/global/security/jwt/sdk/SocialLoginService.java
+++ b/backend/src/main/java/com/kongdak/global/security/jwt/sdk/SocialLoginService.java
@@ -1,0 +1,109 @@
+package com.kongdak.global.security.jwt.sdk;
+
+import com.kongdak.controller.dto.request.MemberCreateRequest;
+import com.kongdak.domain.member.Member;
+import com.kongdak.domain.member.MemberRepository;
+import com.kongdak.domain.member.MemberService;
+import com.kongdak.domain.member.OAuthProvider;
+import com.kongdak.global.exception.BusinessException;
+import com.kongdak.global.exception.ErrorCode;
+import com.kongdak.global.security.jwt.RefreshTokenRepository;
+import com.kongdak.global.security.jwt.TokenPairResponse;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SocialLoginService {
+    private final MemberRepository memberRepository;
+    private final MemberService memberService;
+    private final SimpleJwtTokenProvider simplejwtTokenProvider;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    private static final  String KAKAO_USER_INFO_ULI = "https://kapi.kakao.com/v2/user/me";
+
+    public TokenPairResponse socialLogin(String accessToken, String provider) {
+        // 카카오 엑세스 토큰으로 사용자 정보 조회
+        String email = validateKakaoTokenAndGetEmail(accessToken);
+
+        // 이메일로 회원 조회 또는 가입 처리
+        Member member = memberRepository.findByEmail(email)
+                .orElseGet(() -> memberService.createMember(
+                        new MemberCreateRequest(
+                                email,
+                                generateTempNickname(),
+                                OAuthProvider.from(provider)
+                        )
+                ));
+
+        if (!member.isActive()) {
+            throw new BusinessException(ErrorCode.INACTIVE_MEMBER);
+        }
+
+        // JWT 토큰 발급
+        TokenPairResponse tokenPair = simplejwtTokenProvider.createTokenPair(member);
+
+        // RefreshToken Redis 저장
+        refreshTokenRepository.save(email, tokenPair.refreshToken(),
+                simplejwtTokenProvider.getRefreshTokenValidityInMilliseconds());
+
+        return tokenPair;
+
+    }
+
+    private String validateKakaoTokenAndGetEmail(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+        HttpEntity<?> entity = new HttpEntity<>(headers);
+
+        try {
+            ResponseEntity<KakaoUserInfo> response = restTemplate.exchange(
+                    KAKAO_USER_INFO_ULI,
+                    HttpMethod.GET,
+                    entity,
+                    KakaoUserInfo.class
+            );
+
+            KakaoUserInfo userInfo = response.getBody();
+            if (userInfo == null || userInfo.getKakaoAccount() == null || userInfo.getKakaoAccount().getEmail() == null) {
+                log.error("Failed to get valid user info from Kakao. UserInfo: {}", userInfo);
+                throw new BusinessException(ErrorCode.INVALID_SOCIAL_TOKEN);
+            }
+
+            return userInfo.getKakaoAccount().getEmail();
+        } catch (RestClientException e) {
+            log.error("Failed to get Kakao user info", e);
+            throw new BusinessException(ErrorCode.INVALID_SOCIAL_TOKEN);
+        }
+    }
+
+    private String generateTempNickname() {
+        return "User" + UUID.randomUUID().toString().substring(0, 8);
+    }
+
+    @Getter
+    @NoArgsConstructor
+    private class KakaoUserInfo {
+        private KakaoAccount kakaoAccount;
+
+        @Getter
+        @NoArgsConstructor
+        static class KakaoAccount {
+            private String email;
+        }
+    }
+}


### PR DESCRIPTION
## 카카오 로그인 SDK로 전환

- 카카오 로그인을 SDK 방식으로 전환
- OAuth2 로그인 설정 제거 및 SDK 기반 인증 로직 구현
- 소셜 로그인 관련 새로운 클래스 추가

상세 변경내용
추가된 파일

SocialLoginRequest.java: 소셜 로그인 요청 DTO
SimpleJwtTokenProvider.java: JWT 토큰 관리 클래스
SocialLoginService.java: 카카오 SDK 기반 소셜 로그인 서비스

수정된 파일

SecurityConfig.java: OAuth2 설정 제거
AuthController.java: SDK 기반 로그인 엔드포인트 추가
ErrorCode.java: 소셜 토큰 관련 에러코드 추가

API 변경사항

신규 엔드포인트: /auth/login/{provider}

소셜 액세스 토큰으로 로그인 처리
응답으로 JWT 액세스/리프레시 토큰 페어 반환



테스트 필요사항

카카오 로그인 플로우 전체 테스트
토큰 갱신 프로세스 검증
에러 처리 케이스 확인

# Issue
This closes #90 