### PR TITLE
Inner Class 분리

### DIFF
--- a/backend/src/main/java/com/kongdak/global/security/jwt/sdk/KakaoAccount.java
+++ b/backend/src/main/java/com/kongdak/global/security/jwt/sdk/KakaoAccount.java
@@ -1,0 +1,6 @@
+package com.kongdak.global.security.jwt.sdk;
+
+public record KakaoAccount(
+        String email
+) {
+}

--- a/backend/src/main/java/com/kongdak/global/security/jwt/sdk/KakaoUserInfo.java
+++ b/backend/src/main/java/com/kongdak/global/security/jwt/sdk/KakaoUserInfo.java
@@ -1,0 +1,6 @@
+package com.kongdak.global.security.jwt.sdk;
+
+public record KakaoUserInfo(
+        KakaoAccount kakaoAccount
+) {
+}

--- a/backend/src/main/java/com/kongdak/global/security/jwt/sdk/SocialLoginService.java
+++ b/backend/src/main/java/com/kongdak/global/security/jwt/sdk/SocialLoginService.java
@@ -79,12 +79,12 @@ public class SocialLoginService {
             );
 
             KakaoUserInfo userInfo = response.getBody();
-            if (userInfo == null || userInfo.getKakaoAccount() == null || userInfo.getKakaoAccount().getEmail() == null) {
+            if (userInfo == null || userInfo.kakaoAccount() == null || userInfo.kakaoAccount().email() == null) {
                 log.error("Failed to get valid user info from Kakao. UserInfo: {}", userInfo);
                 throw new BusinessException(ErrorCode.INVALID_SOCIAL_TOKEN);
             }
 
-            return userInfo.getKakaoAccount().getEmail();
+            return userInfo.kakaoAccount().email();
         } catch (RestClientException e) {
             log.error("Failed to get Kakao user info", e);
             throw new BusinessException(ErrorCode.INVALID_SOCIAL_TOKEN);
@@ -93,17 +93,5 @@ public class SocialLoginService {
 
     private String generateTempNickname() {
         return "User" + UUID.randomUUID().toString().substring(0, 8);
-    }
-
-    @Getter
-    @NoArgsConstructor
-    private class KakaoUserInfo {
-        private KakaoAccount kakaoAccount;
-
-        @Getter
-        @NoArgsConstructor
-        static class KakaoAccount {
-            private String email;
-        }
     }
 }


### PR DESCRIPTION
fix : Inner Class 분리(KakaoAccount, KakaoUserInfo)

- JSON 직렬화/역직렬화 라이브러리인 Jackson이 내부 클래스(inner class)를 인스턴스화하지 못해서 발생하는 문제이다.
- Jackson이 객체를 생성할 때는 기본 생성자가 필요하고, non-static inner class는 외부 클래스의 인스턴스 없이는 생성할 수 없기 때문에 이런 에러가 발생한다.
- 두 클래스 모두 public static으로 변경하거나 record, 즉 DTO로 분리하면 된다.