### PR TITLE
LoggingAspect AOP 수정

### DIFF
--- a/backend/src/main/java/com/kongdak/global/aop/LoggingAspect.java
+++ b/backend/src/main/java/com/kongdak/global/aop/LoggingAspect.java
@@ -25,7 +25,7 @@ public class LoggingAspect {
             .registerModule(new JavaTimeModule());
 
     // Controller 레벨 로깅
-    @Around("execution(* com.kongdak..controller..*.*(..))")
+    @Around("execution(* com.kongdak.*.controller..*.*(..))")
     public Object loggingController(ProceedingJoinPoint joinPoint) throws Throwable {
         HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
         String httpMethod = request.getMethod();
@@ -50,7 +50,7 @@ public class LoggingAspect {
     }
 
     // Security 레벨 로깅
-    @Around("execution(* com.kongdak..security..*.*(..))")
+    @Around("execution(* com.kongdak.*.security.*.*(..))")
     public Object loggingSecurity(ProceedingJoinPoint joinPoint) throws Throwable {
         String methodName = joinPoint.getSignature().getName();
         String className = joinPoint.getTarget().getClass().getSimpleName();
@@ -71,7 +71,7 @@ public class LoggingAspect {
     }
 
     // Service 레벨 로깅
-    @Around("execution(* com.kongdak..service..*.*(..))")
+    @Around("execution(* com.kongdak.*.service.*.*(..))")
     public Object loggingService(ProceedingJoinPoint joinPoint) throws Throwable {
         String methodName = joinPoint.getSignature().getName();
         String className = joinPoint.getTarget().getClass().getSimpleName();
@@ -96,7 +96,7 @@ public class LoggingAspect {
     }
 
     // Repository 레벨 로깅
-    @Around("execution(* com.kongdak..repository..*.*(..))")
+    @Around("execution(* com.kongdak.*.repository.*.*(..))")
     public Object loggingRepository(ProceedingJoinPoint joinPoint) throws Throwable {
         String methodName = joinPoint.getSignature().getName();
         String className = joinPoint.getTarget().getClass().getSimpleName();
@@ -127,7 +127,7 @@ public class LoggingAspect {
     }
 
     // SSE/알림 레벨 로깅
-    @Around("execution(* com.kongdak..notification..*.*(..))")
+    @Around("execution(* com.kongdak.*.notification.*.*(..))")
     public Object loggingNotification(ProceedingJoinPoint joinPoint) throws Throwable {
         String methodName = joinPoint.getSignature().getName();
         String className = joinPoint.getTarget().getClass().getSimpleName();

--- a/backend/src/main/java/com/kongdak/global/security/jwt/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/kongdak/global/security/jwt/JwtAuthenticationFilter.java
@@ -60,8 +60,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 path.startsWith("/api/auth") ||
                 path.startsWith("/api/v3/api-docs") ||
                 path.startsWith("/api/swagger-ui/");
-
-        System.out.println("Path: " + path + ", shouldNotFilter = " + shouldNotFilter);
         return shouldNotFilter;
     }
 


### PR DESCRIPTION
- LoggingAspect 에서 `@Around("execution(* com.kongdak..controller..*.*(..))")` 와 같이 사용하여 스프링 내부 컴포넌트까지 가로채려고 시도해서 문제가 발생했었다.

- @Around("execution(* com.kongdak.*.controller.*.*(..))") 로 바꿔서 com.kongdak 바로 아래 패키지 하나만 매칭하고, 정확한 패키지 명을 지정했다.

AOP가 적용되는 범위를 명확히 하고, 불필요한 스프링 내부 컴포넌트를 가로채지 않게 하였다.