### PR TITLE
ELK 스택을 Prometheus와 Grafana로 변경

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -53,9 +53,8 @@ dependencies {
 	// AWS CloudWatch 의존성 추가
 	implementation 'ca.pjer:logback-awslogs-appender:1.6.0'
 
-	// Logstash 의존성
-	implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
-
+	// Prometheus 설정 추가
+	implementation 'io.micrometer:micrometer-registry-prometheus'
 	// Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 	// Swagger 어노테이션 처리

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -9,27 +9,29 @@
         </encoder>
     </appender>
 
-    <!-- Logstash 로그 전송 설정 -->
-    <appender name="LOGSTASH" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
-        <destination>logstash:5000</destination>
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
-            <customFields>{"application":"kongdak"}</customFields>
+    <!-- 파일 로그 (Logstash 대체) -->
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>/logs/kongdak.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>/logs/kongdak.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <maxHistory>7</maxHistory>
+        </rollingPolicy>
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
         </encoder>
     </appender>
 
     <!-- 개발 환경 설정 -->
     <root level="INFO">
         <appender-ref ref="Console" />
-        <appender-ref ref="LOGSTASH" />
+        <appender-ref ref="FILE" />
     </root>
 
     <!-- SQL 로그 -->
     <logger name="org.hibernate.SQL" level="DEBUG">
         <appender-ref ref="Console" />
-        <appender-ref ref="LOGSTASH" />
     </logger>
     <logger name="org.hibernate.type.descriptor.sql" level="TRACE">
         <appender-ref ref="Console" />
-        <appender-ref ref="LOGSTASH" />
     </logger>
 </configuration>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,6 @@ services:
       - mariadb-data:/var/lib/mysql
     networks:
       - kongdak-network
-
   redis:
     image: redis:alpine
     container_name: kongdak-redis
@@ -22,49 +21,53 @@ services:
       - "6379:6379"
     networks:
       - kongdak-network
-
-  elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.12.1
-    container_name: kongdak-elasticsearch
-    environment:
-      - discovery.type=single-node
-      - ES_JAVA_OPTS=-Xms512m -Xmx512m
-      - xpack.security.enabled=false
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: kongdak-prometheus
     volumes:
-      - elasticsearch-data:/usr/share/elasticsearch/data
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+      - prometheus-data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--web.console.libraries=/etc/prometheus/console_libraries'
+      - '--web.console.templates=/etc/prometheus/consoles'
+      - '--storage.tsdb.retention.time=15d'
+      - '--web.enable-lifecycle'
     ports:
-      - "9200:9200"
+      - "9090:9090"
     networks:
       - kongdak-network
-
-  logstash:
-    image: docker.elastic.co/logstash/logstash:8.12.1
-    container_name: kongdak-logstash
+  node-exporter:
+    image: prom/node-exporter:latest
+    container_name: kongdak-node-exporter
     volumes:
-      - ./elk/logstash/config/logstash.yml:/usr/share/logstash/config/logstash.yml:ro
-      - ./elk/logstash/pipeline:/usr/share/logstash/pipeline:ro
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /:/rootfs:ro
+    command:
+      - '--path.procfs=/host/proc'
+      - '--path.rootfs=/rootfs'
+      - '--path.sysfs=/host/sys'
+      - '--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)'
     ports:
-      - "5044:5044"
-      - "5000:5000/tcp"
+      - "9100:9100"
+    networks:
+      - kongdak-network
+  grafana:
+    image: grafana/grafana:latest
+    container_name: kongdak-grafana
+    ports:
+      - "3001:3000"
+    volumes:
+      - grafana-data:/var/lib/grafana
     environment:
-      LS_JAVA_OPTS: "-Xmx256m -Xms256m"
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_USERS_ALLOW_SIGN_UP=false
     networks:
       - kongdak-network
     depends_on:
-      - elasticsearch
-
-  kibana:
-    image: docker.elastic.co/kibana/kibana:8.12.1
-    container_name: kongdak-kibana
-    ports:
-      - "5601:5601"
-    environment:
-      - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
-    networks:
-      - kongdak-network
-    depends_on:
-      - elasticsearch
-
+      - prometheus
   backend:
     build: 
       context: ./backend
@@ -75,7 +78,7 @@ services:
     depends_on:
       - mariadb
       - redis
-      - logstash
+      - prometheus
     environment:
       SPRING_DATASOURCE_URL: jdbc:mariadb://mariadb:3306/kongdak?serverTimezone=Asia/Seoul&useSSL=false&allowPublicKeyRetrieval=true
       SPRING_DATASOURCE_USERNAME: kongdak_user
@@ -90,7 +93,6 @@ services:
       SPRING_REDIS_PORT: 6379
     networks:
       - kongdak-network
-
   frontend:
     build:
       context: ./frontend
@@ -102,11 +104,10 @@ services:
       - backend
     networks:
       - kongdak-network
-
 networks:
   kongdak-network:
     driver: bridge
-
 volumes:
   mariadb-data:
-  elasticsearch-data:
+  prometheus-data:
+  grafana-data:

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,0 +1,17 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']
+
+  - job_name: 'node'
+    static_configs:
+      - targets: ['node-exporter:9100']
+
+  - job_name: 'spring-actuator'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['backend:8080']

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -5,7 +5,7 @@ global:
 scrape_configs:
   - job_name: 'prometheus'
     static_configs:
-      - targets: ['localhost:9090']
+      - targets: ['prometheus:9090']
 
   - job_name: 'node'
     static_configs:


### PR DESCRIPTION
# ELK 스택을 Prometheus와 Grafana로 변경

## 변경 개요
- ELK 스택(Elasticsearch, Logstash, Kibana) 제거
- Prometheus와 Grafana 기반 모니터링 시스템 도입
- 로깅 시스템 간소화 (파일 기반)
- 백엔드 애플리케이션에 Prometheus 메트릭 지원 추가

## 주요 변경사항
1. **의존성 변경**: Logstash 의존성 제거, Prometheus 의존성 추가
2. **로깅 설정**: Logstash TCP 전송 방식에서 파일 기반 로깅으로 변경
3. **인프라 구성**: 
   - ELK 스택 컨테이너 제거
   - Prometheus, Node Exporter, Grafana 컨테이너 추가
   - 필요한 볼륨 및 설정 구성
4. **메트릭 설정**: Spring Boot Actuator와 Prometheus 연동 설정

## 테스트
- 시스템 리소스 사용량 감소 확인
- t2.micro 인스턴스에서도 안정적인 운영 가능한지 확인
- 모니터링 시스템 설정 간소화 확인

## 참고사항
- Grafana 초기 접속 정보: admin/admin (배포 후 변경 필요)
- 메트릭 데이터 보존 기간: 15일
- 로그 파일 보존 기간: 7일