### PR TITLE
Social 로그인 서비스 에러처리 세분화

### DIFF
--- a/backend/src/main/java/com/kongdak/global/security/jwt/sdk/SocialLoginService.java
+++ b/backend/src/main/java/com/kongdak/global/security/jwt/sdk/SocialLoginService.java
@@ -72,7 +72,7 @@ public class SocialLoginService {
             log.info("카카오 user info 요청 with access token: {}", accessToken);
             ResponseEntity<KakaoUserInfo> response = restTemplate.exchange(
                     KAKAO_USER_INFO_URI,
-                    HttpMethod.GET,
+                    HttpMethod.POST,
                     entity,
                     KakaoUserInfo.class
             );


### PR DESCRIPTION
- INVALID_TOKEN_ERROR가 떴었는데, 클라이언트 사이드의 문제인지 서버 측의 문제인지 확실하지 않아 에러 처리를 세분화 시켜서 확인해보도록 한다.