### PR TITLE
Kakao API UserInfo 요청 형식 변경

### DIFF
--- a/backend/src/main/java/com/kongdak/global/security/jwt/sdk/KakaoAccount.java
+++ b/backend/src/main/java/com/kongdak/global/security/jwt/sdk/KakaoAccount.java
@@ -1,6 +1,12 @@
 package com.kongdak.global.security.jwt.sdk;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public record KakaoAccount(
+        @JsonProperty("has_email") Boolean hasEmail,
+        @JsonProperty("email_needs_agreement") Boolean emailNeedsAgreement,
+        @JsonProperty("is_email_valid") Boolean isEmailValid,
+        @JsonProperty("is_email_verified") Boolean isEmailVerified,
         String email
 ) {
 }

--- a/backend/src/main/java/com/kongdak/global/security/jwt/sdk/KakaoUserInfo.java
+++ b/backend/src/main/java/com/kongdak/global/security/jwt/sdk/KakaoUserInfo.java
@@ -1,6 +1,10 @@
 package com.kongdak.global.security.jwt.sdk;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public record KakaoUserInfo(
-        KakaoAccount kakaoAccount
+        Long id,
+        @JsonProperty("connected_at") String connectedAt,
+        @JsonProperty("kakao_account") KakaoAccount kakaoAccount
 ) {
 }

--- a/backend/src/main/java/com/kongdak/global/security/jwt/sdk/SocialLoginService.java
+++ b/backend/src/main/java/com/kongdak/global/security/jwt/sdk/SocialLoginService.java
@@ -72,7 +72,7 @@ public class SocialLoginService {
             log.info("카카오 user info 요청 with access token: {}", accessToken);
             ResponseEntity<KakaoUserInfo> response = restTemplate.exchange(
                     KAKAO_USER_INFO_URI,
-                    HttpMethod.POST,
+                    HttpMethod.GET,
                     entity,
                     KakaoUserInfo.class
             );


### PR DESCRIPTION
# Kakao API UserInfo 요청 형식 변경

## 변경사항
1. KakaoUserInfo 클래스 구조 변경
   - `id` 필드 추가
   - `connectedAt` 필드 추가
   - `kakaoAccount` 필드에 `@JsonProperty("kakao_account")` 어노테이션 추가

2. KakaoAccount 클래스에 이메일 관련 필드 추가
   - `hasEmail`
   - `emailNeedsAgreement`
   - `isEmailValid`
   - `isEmailVerified`

3. Kakao API 요청 메소드 변경
   - HTTP 메소드를 POST에서 GET으로 변경
