### PR TITLE
OAuth 로그인시 Nickname 변경 여부 추가

### DIFF
--- a/backend/src/main/java/com/kongdak/domain/member/Member.java
+++ b/backend/src/main/java/com/kongdak/domain/member/Member.java
@@ -29,6 +29,10 @@ public class Member extends BaseTimeEntity {
     @Column(nullable = false)
     private boolean isActive = true;
 
+    @Column(nullable = false)
+    @Setter
+    private boolean nicknameSet = false;
+
     @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "couple_id")

--- a/backend/src/main/java/com/kongdak/domain/member/MemberService.java
+++ b/backend/src/main/java/com/kongdak/domain/member/MemberService.java
@@ -48,7 +48,7 @@ public class MemberService {
     public MemberResponse updateNickname(String email, String nickname) {
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
-
+        member.setNicknameSet(true);
         member.updateNickname(nickname);
 
         // 파트너 정보 조회

--- a/backend/src/main/java/com/kongdak/global/security/jwt/TokenPairResponse.java
+++ b/backend/src/main/java/com/kongdak/global/security/jwt/TokenPairResponse.java
@@ -8,6 +8,9 @@ public record TokenPairResponse(
         @Schema(description = "Access 토큰", example = "eyJhbGciOiJIUzI1NiIs...")
         String accessToken,
         @Schema(description = "리프레시 토큰", example = "eyJhbGciOiJIUzI1NiIs...")
-        String refreshToken
+        String refreshToken,
+
+        @Schema(description = "닉네임 변경 여부", example = "true")
+        boolean isNicknameSet
 ) {
 }

--- a/backend/src/main/java/com/kongdak/global/security/jwt/sdk/SimpleJwtTokenProvider.java
+++ b/backend/src/main/java/com/kongdak/global/security/jwt/sdk/SimpleJwtTokenProvider.java
@@ -47,7 +47,7 @@ public class SimpleJwtTokenProvider {
         String accessToken = createAccessToken(member);
         String refreshToken = createRefreshToken(member.getEmail(), member.getId());
 
-        return new TokenPairResponse(accessToken, refreshToken);
+        return new TokenPairResponse(accessToken, refreshToken, member.isNicknameSet());
     }
 
     private String createAccessToken(Member member) {
@@ -166,6 +166,6 @@ public class SimpleJwtTokenProvider {
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
 
-        return new TokenPairResponse((newAccessToken), newRefreshToken);
+        return new TokenPairResponse(newAccessToken, newRefreshToken, true);
     }
 }


### PR DESCRIPTION

- OAuth2.0 로그인 후에
  - 처음 로그인을 한 뒤에는 닉네임을 변경하게 해야하고
  - 다음 로그인부터는 닉네임 변경 창으로 이동하지 않게 해야한다.
즉, 클라이언트에서 유저가 첫 로그인시(회원가입 시) 닉네임을 변경하라고 요구하여야 한다. 이 여부를 알 수 없으니 Member 엔티티에 isNicknameSet 컬럼을 추가하고 보내준다.
---
## 고려사항
### 1. 상태코드로 구분하기
- 장점: 구현이 단순하고 추가 데이터베이스 변경이 필요 없음
- 단점: HTTP 상태코드의 의미론적 사용에 맞지 않음 (201은 리소스 생성을 의미)
- 보안: 상태 정보가 클라이언트에 노출됨

### 2. RDBMS에 nickname_set 컬럼 추가하기
- 장점: 상태 관리가 명확하고 영구적이며 회원 정보와 함께 관리됨
- 단점: 데이터베이스 스키마 변경 필요
- 보안: 서버 측에서 안전하게 관리됨

3. Redis에 key-value로 관리
- 장점: 데이터베이스 스키마 변경 없이 빠르게 조회 가능
- 단점: Redis 장애 시 상태 정보 손실 가능성, 관리 포인트 증가
- 보안: 서버 측에서 안전하게 관리됨
---

RDBMS에 nickname_set 불리언 필드를 추가하였음.

- 회원 상태는 영구적으로 저장되어야 하는 중요한 정보이다.
- 이미 Member 테이블이 있어 스키마 변경이 어렵지 않다.
- 닉네임 설정 여부는 회원의 본질적인 속성이므로 회원 엔티티에 있는 것이 자연스럽다.
- OAuth 로그인 응답 DTO에 nicknameSet 필드를 추가하여 클라이언트에 정보 제공