### PR TITLE
아이디 활성화 엔드포인트 추가

### DIFF
--- a/backend/src/main/java/com/kongdak/controller/MemberController.java
+++ b/backend/src/main/java/com/kongdak/controller/MemberController.java
@@ -1,6 +1,7 @@
 package com.kongdak.controller;
 
 import com.kongdak.controller.dto.request.NicknameUpdateRequest;
+import com.kongdak.controller.dto.response.ActivateResponse;
 import com.kongdak.controller.dto.response.DeactivateResponse;
 import com.kongdak.controller.dto.response.MemberResponse;
 import com.kongdak.domain.member.MemberService;
@@ -53,11 +54,22 @@ public class MemberController {
     @Operation(summary = "회원 탈퇴", description = "회원 계정을 비활성화합니다.")
     @ApiResponse(responseCode = "200", description = "탈퇴 성공",
             content = @Content(schema = @Schema(implementation = BaseResponse.class)))
-    @DeleteMapping
+    @PatchMapping("/deactivate")
     public BaseResponse<DeactivateResponse> deactivateMember(
             @Parameter(description = "인증된 사용자 정보", hidden = true)
             @AuthenticationPrincipal CustomUserDetails userDetails) {
 
         return BaseResponse.ok(memberService.deactivateMember(userDetails.getUsername()));
+    }
+
+    @Operation(summary = "회원 복구", description = "회원 계정을 활성화합니다.")
+    @ApiResponse(responseCode = "200", description = "복구 성공",
+            content = @Content(schema = @Schema(implementation = BaseResponse.class)))
+    @PatchMapping("/activate")
+    public BaseResponse<ActivateResponse> activateMember(
+            @Parameter(description = "인증된 사용자 정보", hidden = true)
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        return BaseResponse.ok(memberService.activateMember(userDetails.getUsername()));
     }
 }

--- a/backend/src/main/java/com/kongdak/controller/dto/response/ActivateResponse.java
+++ b/backend/src/main/java/com/kongdak/controller/dto/response/ActivateResponse.java
@@ -1,0 +1,15 @@
+package com.kongdak.controller.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "회원 복구 응답")
+public record ActivateResponse(
+        @Schema(description = "복구 처리된 이메일", example = "user@example.com")
+        String email,
+
+        @Schema(description = "복구 처리 시간", example = "2024-01-19T18:30:00")
+        LocalDateTime ActivatedAt
+) {
+}

--- a/backend/src/main/java/com/kongdak/controller/dto/response/DeactivateResponse.java
+++ b/backend/src/main/java/com/kongdak/controller/dto/response/DeactivateResponse.java
@@ -11,8 +11,5 @@ public record DeactivateResponse(
         String email,
 
         @Schema(description = "탈퇴 처리 시간", example = "2024-01-19T18:30:00")
-        LocalDateTime deactivatedAt,
-
-        @Schema(description = "처리 상태 메시지", example = "회원 탈퇴가 완료되었습니다.")
-        String message
+        LocalDateTime deactivatedAt
 ) {}

--- a/backend/src/main/java/com/kongdak/domain/member/MemberService.java
+++ b/backend/src/main/java/com/kongdak/domain/member/MemberService.java
@@ -1,6 +1,7 @@
 package com.kongdak.domain.member;
 
 import com.kongdak.controller.dto.request.MemberCreateRequest;
+import com.kongdak.controller.dto.response.ActivateResponse;
 import com.kongdak.controller.dto.response.DeactivateResponse;
 import com.kongdak.controller.dto.response.MemberResponse;
 import com.kongdak.global.exception.BusinessException;
@@ -68,8 +69,18 @@ public class MemberService {
 
         return new DeactivateResponse(
                 email,
-                LocalDateTime.now(),
-                "회원 탈퇴가 완료되었습니다."
+                LocalDateTime.now()
+        );
+    }
+
+    @Transactional
+    public ActivateResponse activateMember(String email) {
+        Member member = findByEmail(email);
+        member.activate();
+
+        return new ActivateResponse(
+                email,
+                LocalDateTime.now()
         );
     }
 


### PR DESCRIPTION
# 아이디 활성화 엔드포인트 추가

## 변경 내용 요약
- 비활성화된 회원 계정을 활성화하는 엔드포인트 추가
- 회원 탈퇴 엔드포인트를 DeleteMapping에서 PatchMapping으로 변경
- 관련 DTO 클래스 및 서비스 로직 구현

## 문제점
- 현재 아이디 상태를 비활성화 시키는 엔드포인트는 있으나, 활성화 시키는 엔드포인트가 존재하지 않음
- 회원 탈퇴 메서드가 DeleteMapping으로 구현되어 있어 RESTful 설계와 불일치

## 구현 내용
- 회원 복구 기능을 위한 `PatchMapping("/activate")` 엔드포인트 추가
- 회원 탈퇴 메서드도 `PatchMapping("/deactivate")`로 변경
- `ActivateResponse` DTO 클래스 추가
- `DeactivateResponse` 클래스에서 불필요한 message 필드 제거
- `MemberService`에 `activateMember()` 메서드 구현