### PR TITLE
버킷리스트 생성자 수정

### DIFF
--- a/backend/src/main/java/com/kongdak/domain/bucketlist/BucketList.java
+++ b/backend/src/main/java/com/kongdak/domain/bucketlist/BucketList.java
@@ -9,7 +9,6 @@ import lombok.*;
 @Table(name = "bucket_list")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@RequiredArgsConstructor
 public class BucketList extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
- 현재 필수 필드가 없으나 `@NoArgsConstructor(access = AccessLevel.PROTECTED)` 와 `@RequiredArgsConstructor` 를 함께 사용하고 있다.

-생성자 중복 에러가 발생하므로 `@RequiredArgsConstructor` 를 제거해주도록 한다.