### PR TITLE
fix: 버킷리스트 생성자 수정

### DIFF
--- a/backend/src/main/java/com/kongdak/controller/BucketListController.java
+++ b/backend/src/main/java/com/kongdak/controller/BucketListController.java
@@ -38,7 +38,7 @@ public class BucketListController {
         return BaseResponse.created(bucketList);
     }
 
-    @PatchMapping("/bucketlists/{bucketlistId")
+    @PatchMapping("/bucketlists/{bucketlistId}")
     public BaseResponse<BucketListResponseDto> updateBucketList(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable("bucketlistId") Long bucketListId,


### PR DESCRIPTION
- 현재 필수 필드가 없으나 `@NoArgsConstructor(access = AccessLevel.PROTECTED)` 와 `@RequiredArgsConstructor` 를 함께 사용하고 있다.

-생성자 중복 에러가 발생하므로 `@RequiredArgsConstructor` 를 제거해주도록 한다.