### PR TITLE
로그인 시 유저 활성화 상태 체크 삭제

### DIFF
--- a/backend/src/main/java/com/kongdak/controller/dto/response/CoupleResponse.java
+++ b/backend/src/main/java/com/kongdak/controller/dto/response/CoupleResponse.java
@@ -1,9 +1,6 @@
 package com.kongdak.controller.dto.response;
 
 import com.kongdak.domain.couple.Couple;
-import com.kongdak.domain.member.MemberRepository;
-import com.kongdak.global.exception.BusinessException;
-import com.kongdak.global.exception.ErrorCode;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;

--- a/backend/src/main/java/com/kongdak/global/security/jwt/sdk/SocialLoginService.java
+++ b/backend/src/main/java/com/kongdak/global/security/jwt/sdk/SocialLoginService.java
@@ -48,10 +48,6 @@ public class SocialLoginService {
                         )
                 ));
 
-        if (!member.isActive()) {
-            throw new BusinessException(ErrorCode.INACTIVE_MEMBER);
-        }
-
         // JWT 토큰 발급
         TokenPairResponse tokenPair = simplejwtTokenProvider.createTokenPair(member);
 


### PR DESCRIPTION
- 기존 SDK 로그인 시 유저 상태가 활성화 되어 있지 않았을 때 로그인을 할 수 없게 구현이 되어 있었다. 
- -해당 상황에서는 재활성화 요청인 "/members/activate" 요청의 권한도 없는 상황이기에 해당 사항을 삭제하기로 한다.