### PR TITLE
MemberResponse NullPointer Exception 처리

### DIFF
--- a/backend/src/main/java/com/kongdak/controller/dto/response/MemberResponse.java
+++ b/backend/src/main/java/com/kongdak/controller/dto/response/MemberResponse.java
@@ -37,7 +37,7 @@ public record MemberResponse(
         return new MemberResponse(
             member.getId(),
                 member.getNickname(),
-                partner.getNickname(),
+                partner != null ? partner.getNickname() : null,
                 member.getEmail(),
                 member.getOauthProvider(),
                 member.getCreatedAt(),


### PR DESCRIPTION
- `partner.getNickname`을 직접 사용하는 것은 NullPointer을 낼 수 있어 
`partner != null ? partner.getNickname() : null`로 처리하도록 한다.