### PR TITLE
S3 fileKey 직접 받는 방식으로 변경

### DIFF
--- a/backend/src/main/java/com/kongdak/controller/DiaryController.java
+++ b/backend/src/main/java/com/kongdak/controller/DiaryController.java
@@ -43,9 +43,10 @@ public class DiaryController {
         // 프리사인드 URL을 반환하도록 수정
         List<String> fileUrls = files.stream()
                 .map(file -> {
-                    String url = s3Service.uploadFile(file);
-                    String fileName = s3Service.extractFileNameFromUrl(url);
-                    return s3Service.generatePresignedUrl(fileName, Duration.ofDays(7));
+
+                    // 파일 키를 직접 받는 방식으로 변경
+                    String fileKey = s3Service.uploadFile(file);
+                    return s3Service.generatePresignedUrl(fileKey, Duration.ofDays(7));
                 })
                 .collect(Collectors.toList());
 

--- a/backend/src/main/java/com/kongdak/domain/diary/S3/S3Service.java
+++ b/backend/src/main/java/com/kongdak/domain/diary/S3/S3Service.java
@@ -53,7 +53,8 @@ public class S3Service {
             s3Client.putObject(putObjectRequest,
                     RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
 
-            return generateUrl(fileName);
+            // 파일 키만 반환
+            return fileName;
         } catch (IOException e) {
             log.error("파일 업로드 중 오류 발생: {}", e.getMessage(), e);
             throw new BusinessException(ErrorCode.FILE_UPLOAD_ERROR);

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -11,7 +11,7 @@
 
     <!-- 파일 로그 (Logstash 대체) -->
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>/logs/kongdak.log</file>
+        <file>./logs/kongdak.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <fileNamePattern>/logs/kongdak.%d{yyyy-MM-dd}.log</fileNamePattern>
             <maxHistory>7</maxHistory>


### PR DESCRIPTION
파일 구조마다 변경되는 파일명을 추출하는 현재 방식보다는 S3 fileKey를 직접 받아서 관리하는 방식으로 변경하여 더 튼튼한 방식을 고수하도록 변경