### PR TITLE
S3 key 반환 방식 및 photo URL 길이 변경

### DIFF
--- a/backend/src/main/java/com/kongdak/controller/DiaryController.java
+++ b/backend/src/main/java/com/kongdak/controller/DiaryController.java
@@ -23,6 +23,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.time.Duration;
 import java.time.YearMonth;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @RestController
@@ -40,17 +41,19 @@ public class DiaryController {
             @Parameter(description = "업로드할 사진 파일들")
             @RequestParam("files") List<MultipartFile> files
     ) {
-        // 프리사인드 URL을 반환하도록 수정
-        List<String> fileUrls = files.stream()
-                .map(file -> {
+        // S3에 파일 업로드하고 객체 키만 반환
+        List<String> fileKeys = files.stream()
+                                     .map(s3Service::uploadFile)
+                                     .collect(Collectors.toList());
 
-                    // 파일 키를 직접 받는 방식으로 변경
-                    String fileKey = s3Service.uploadFile(file);
-                    return s3Service.generatePresignedUrl(fileKey, Duration.ofDays(7));
-                })
-                .collect(Collectors.toList());
+        // 사용자에게는 객체 키와 임시 미리보기용 Presigned URL을 함께 제공
+        Map<String, String> keyUrlMap = fileKeys.stream()
+                                                .collect(Collectors.toMap(
+                                                        key -> key,  // 키는 S3 객체 키
+                                                        key -> s3Service.generatePresignedUrl(key, Duration.ofHours(24))  // 값은 24시간 유효한 Presigned URL
+                                                ));
 
-        return BaseResponse.ok(new DiaryPhotoUploadResponse(fileUrls));
+        return BaseResponse.ok(new DiaryPhotoUploadResponse(fileKeys, keyUrlMap));
     }
 
     @Operation(summary = "다이어리 작성", description = "새로운 다이어리를 작성합니다.")

--- a/backend/src/main/java/com/kongdak/domain/diary/dto/request/CreateDiaryRequest.java
+++ b/backend/src/main/java/com/kongdak/domain/diary/dto/request/CreateDiaryRequest.java
@@ -24,7 +24,7 @@ public record CreateDiaryRequest(
         @NotNull
         LocalDate diaryDate,
 
-        @Schema(description = "첨부된 사진 URL 목록", example = "[\"photo1.jpg\", \"photo2.jpg\"]")
+        @Schema(description = "첨부된 사진 URL 목록", example = "[\"photo-keys/uuid1.jpg\", \"photo-keys/uuid2.jpg\"]")
         List<String> photoUrls,
 
         @Schema(description = "데코레이션 목록")

--- a/backend/src/main/java/com/kongdak/domain/diary/dto/response/DiaryDetailResponse.java
+++ b/backend/src/main/java/com/kongdak/domain/diary/dto/response/DiaryDetailResponse.java
@@ -40,16 +40,15 @@ public record DiaryDetailResponse(
         LocalDateTime updatedAt
 
 ) {
-    public static DiaryDetailResponse from(Diary diary) {
+
+    public static DiaryDetailResponse from(Diary diary, List<PhotoResponse> photos) {
         return new DiaryDetailResponse(
                 diary.getId(),
                 diary.getContent(),
                 diary.getEmotion(),
                 diary.getWeather(),
                 diary.getDiaryDate(),
-                diary.getPhotos().stream()
-                        .map(PhotoResponse::from)
-                        .toList(),
+                photos,
                 diary.getDecorations().stream()
                         .map(DecorationResponse::from)
                         .toList(),

--- a/backend/src/main/java/com/kongdak/domain/diary/dto/response/DiaryPhotoUploadResponse.java
+++ b/backend/src/main/java/com/kongdak/domain/diary/dto/response/DiaryPhotoUploadResponse.java
@@ -1,8 +1,10 @@
 package com.kongdak.domain.diary.dto.response;
 
 import java.util.List;
+import java.util.Map;
 
 public record DiaryPhotoUploadResponse(
-        List<String> photoUrls
+        List<String> photoUrls,
+        Map<String, String> previewUrls
 ) {
 }

--- a/backend/src/main/java/com/kongdak/domain/diary/entity/DiaryPhoto.java
+++ b/backend/src/main/java/com/kongdak/domain/diary/entity/DiaryPhoto.java
@@ -6,6 +6,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
 
 @Entity
 @Getter
@@ -21,9 +22,10 @@ public class DiaryPhoto extends BaseTimeEntity {
     @JoinColumn(name = "diary_id")
     private Diary diary;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 1000)  // 길이를 1000으로 변경
     private String photoUrl;
 
+    @Column(length = 1000)
     private String thumbnailUrl;
 
     @Builder

--- a/backend/src/main/java/com/kongdak/domain/diary/service/DiaryService.java
+++ b/backend/src/main/java/com/kongdak/domain/diary/service/DiaryService.java
@@ -1,5 +1,7 @@
 package com.kongdak.domain.diary.service;
 
+import com.kongdak.domain.calendar.dto.response.PhotoResponse;
+import com.kongdak.domain.diary.S3.S3Service;
 import com.kongdak.domain.diary.dto.request.CreateDiaryRequest;
 import com.kongdak.domain.diary.dto.request.DecorationUpdateRequest;
 import com.kongdak.domain.diary.dto.request.DiaryUpdateRequest;
@@ -23,6 +25,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.HashMap;
@@ -46,6 +49,7 @@ public class DiaryService {
     private final MemberRepository memberRepository;
     private final CoupleRepository coupleRepository;
     private final RedisLockRepository redisLockRepository;
+    private final S3Service s3Service;
 
     @Transactional
     public Long createDiary(Long memberId, CreateDiaryRequest request) {
@@ -172,7 +176,25 @@ public class DiaryService {
     public DiaryDetailResponse getDiary(Long memberId, Long diaryId) {
         Couple couple = getCoupleByMemberId(memberId);
         Diary diary = getDiaryByIdAndCoupleId(diaryId, couple.getId());
-        return DiaryDetailResponse.from(diary);
+
+        // 사진 URL 생성 로직을 서비스 레이어로 이동
+        List<PhotoResponse> photoResponses = generatePhotoResponses(diary);
+
+        return DiaryDetailResponse.from(diary, photoResponses);
+    }
+
+    private List<PhotoResponse> generatePhotoResponses(Diary diary) {
+        return diary.getPhotos().stream()
+                    .map(photo -> {
+                        String photoUrl = s3Service.generatePresignedUrl(photo.getPhotoUrl(), Duration.ofHours(24));
+                        String thumbnailUrl = s3Service.generatePresignedUrl(photo.getThumbnailUrl(), Duration.ofHours(24));
+                        return new PhotoResponse(
+                                photo.getId(),
+                                photoUrl,
+                                thumbnailUrl
+                        );
+                    })
+                    .collect(Collectors.toList());
     }
 
     public SearchDiaryResponse searchDiaries(Long memberId, YearMonth dateTime) {


### PR DESCRIPTION
# S3 key 반환 방식 및 photo URL 길이 변경

## 변경사항

### 1. 사진 업로드 API 변경
- S3에 파일 업로드 후 단순 Presigned URL 대신 파일 키와 미리보기 URL 맵을 함께 반환
- Presigned URL의 유효기간을 7일에서 24시간으로 단축
- `DiaryPhotoUploadResponse` 클래스에 `photoUrls`와 `previewUrls` 필드 추가

### 2. 사진 URL 길이 확장
- `DiaryPhoto` 엔티티의 `photoUrl` 및 `thumbnailUrl` 필드 길이를 255에서 1000으로 확장

### 3. DiaryService 로직 개선
- Presigned URL 생성 로직을 DTO에서 서비스 레이어로 이동
- `generatePhotoResponses()` 메서드 추가로 코드 재사용성 향상

## 목적
- S3 Presigned URL 만료로 인한 이미지 접근 문제 해결
- 긴 URL을 저장할 수 있도록 데이터베이스 스키마 개선