### PR TITLE
photoUrl 보낼때 원본(db) 과 S3 presigned version 함께 보내는 방식으로 변경

### DIFF
--- a/backend/src/main/java/com/kongdak/domain/calendar/dto/response/PhotoResponse.java
+++ b/backend/src/main/java/com/kongdak/domain/calendar/dto/response/PhotoResponse.java
@@ -8,17 +8,12 @@ public record PhotoResponse(
         @Schema(description = "사진 ID", example = "1")
         Long photoId,
 
-        @Schema(description = "원본 URL", example = "https://example.com/photo.jpg")
-        String photoUrl,
+        @Schema(description = "DB에 저장된 URL", example = "diary/origin_photo.jpg")
+        String dbPhotoUrl,
+        @Schema(description = "S3에서 제공되는 presigned URL", example = "https://example.com/photo.jpg")
+        String S3PhotoUrl,
 
-        @Schema(description = "썸네일 URL", example = "https://example.com/thumbnail.jpg")
+        @Schema(description = "S3에서 제공되는 presigned 썸네일 URL", example = "https://example.com/thumbnail.jpg")
         String thumbnailUrl
 ) {
-    public static PhotoResponse from(DiaryPhoto photo) {
-        return new PhotoResponse(
-                photo.getId(),
-                photo.getPhotoUrl(),
-                photo.getThumbnailUrl()
-        );
-    }
 }

--- a/backend/src/main/java/com/kongdak/domain/diary/service/DiaryService.java
+++ b/backend/src/main/java/com/kongdak/domain/diary/service/DiaryService.java
@@ -190,6 +190,7 @@ public class DiaryService {
                         String thumbnailUrl = s3Service.generatePresignedUrl(photo.getThumbnailUrl(), Duration.ofHours(24));
                         return new PhotoResponse(
                                 photo.getId(),
+                                photo.getPhotoUrl(),
                                 photoUrl,
                                 thumbnailUrl
                         );


### PR DESCRIPTION
- Diary 수정에서 사진의 원본 URL이 있어야 수정 후에 URL을 잘 인지 할 수 있으므로 함께 보내주도록 변경한다.