### PR TITLE
알림(SSE) 구현 및 서비스 확장

### DIFF
--- a/backend/src/main/java/com/kongdak/controller/CalendarController.java
+++ b/backend/src/main/java/com/kongdak/controller/CalendarController.java
@@ -8,6 +8,7 @@ import com.kongdak.domain.calendar.dto.response.ScheduleDetailResponse;
 import com.kongdak.domain.calendar.dto.response.ScheduleResponse;
 import com.kongdak.domain.calendar.service.CalendarService;
 import com.kongdak.global.response.BaseResponse;
+import com.kongdak.global.security.jwt.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -17,6 +18,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
@@ -101,8 +103,9 @@ public class CalendarController {
     })
     @PostMapping("/schedules")
     public BaseResponse<ScheduleResponse> createSchedule(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @Valid @RequestBody ScheduleCreateRequest request) {
-        return BaseResponse.created(calendarService.createSchedule(request));
+        return BaseResponse.created(calendarService.createSchedule(request,  userDetails.getId()));
     }
 
 
@@ -119,9 +122,10 @@ public class CalendarController {
     })
     @PatchMapping("/schedules/{scheduleId}")
     public BaseResponse<ScheduleResponse> updateSchedule(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable("scheduleId") Long scheduleId,
             @Valid @RequestBody ScheduleUpdateRequest request) {
-        ScheduleResponse scheduleResponse = calendarService.updateSchedule(scheduleId, request);
+        ScheduleResponse scheduleResponse = calendarService.updateSchedule(userDetails.getId(), scheduleId, request);
         return BaseResponse.ok(scheduleResponse);
     }
 

--- a/backend/src/main/java/com/kongdak/domain/bucketlist/service/BucketListService.java
+++ b/backend/src/main/java/com/kongdak/domain/bucketlist/service/BucketListService.java
@@ -7,6 +7,8 @@ import com.kongdak.domain.bucketlist.entity.BucketList;
 import com.kongdak.domain.bucketlist.repository.BucketListRepository;
 import com.kongdak.domain.couple.entity.Couple;
 import com.kongdak.domain.couple.service.CoupleService;
+import com.kongdak.domain.member.service.MemberService;
+import com.kongdak.domain.notification.service.NotificationService;
 import com.kongdak.global.exception.BusinessException;
 import com.kongdak.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -24,7 +26,8 @@ import java.util.stream.Collectors;
 public class BucketListService {
     private final BucketListRepository bucketListRepository;
     private final CoupleService coupleService;
-
+    private final MemberService memberService;
+    private final NotificationService notificationService;
     public List<BucketListResponseDto> getBucketLists(Long memberId) {
         Couple couple = coupleService.findCoupleByMemberId(memberId);
         List<BucketList> bucketLists = bucketListRepository.findByCoupleIdOrderByOrderNumAsc(couple.getId());
@@ -49,6 +52,9 @@ public class BucketListService {
                 .category(dto.category())
                 .orderNum(newOrder)
                 .build();
+
+        Long partnerId = memberService.getPartnerIdByMemberId(memberId);
+        notificationService.sendBucketCreatedNotification(bucketList.getId(), memberId, partnerId);
         BucketList savedBucketList = bucketListRepository.save(bucketList);
         return BucketListResponseDto.from(savedBucketList);
     }
@@ -63,6 +69,10 @@ public class BucketListService {
 
         if (dto.isCompleted() != null) {
             bucketList.toggleCompletion();
+        }
+        if (bucketList.isCompleted()){
+            Long partnerId = memberService.getPartnerIdByMemberId(memberId);
+            notificationService.sendBucketCompletedNotification(bucketListId, memberId, partnerId);
         }
 
         return BucketListResponseDto.from(bucketList);

--- a/backend/src/main/java/com/kongdak/domain/calendar/service/CalendarService.java
+++ b/backend/src/main/java/com/kongdak/domain/calendar/service/CalendarService.java
@@ -14,6 +14,7 @@ import com.kongdak.domain.couple.entity.Couple;
 import com.kongdak.domain.couple.service.CoupleService;
 import com.kongdak.domain.member.entity.Member;
 import com.kongdak.domain.member.service.MemberService;
+import com.kongdak.domain.notification.service.NotificationService;
 import com.kongdak.global.exception.BusinessException;
 import com.kongdak.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -34,7 +35,8 @@ public class CalendarService {
     private final ScheduleRepository scheduleRepository;
     private final HolidayRepository holidayRepository;
     private final MemberService memberService;
-    private final CoupleService coupleService;  // 추가
+    private final CoupleService coupleService;
+    private final NotificationService notificationService;
 
     // 캘린더 생성 (커플 연결 시 자동 생성)
     @Transactional
@@ -81,12 +83,10 @@ public class CalendarService {
     // 월별 휴일 조회
     public List<HolidayResponse> getMonthlyHolidays(LocalDateTime dateTime) {
 
-        return holidayRepository.findByYearAndMonth(
-                dateTime.getYear(),
-                dateTime.getMonthValue())
-                .stream()
-                .map(HolidayResponse::from)
-                .collect(Collectors.toList());
+        return holidayRepository.findByYearAndMonth(dateTime.getYear(), dateTime.getMonthValue())
+                                .stream()
+                                .map(HolidayResponse::from)
+                                .collect(Collectors.toList());
     }
 
     // 일별 일정 조회
@@ -95,14 +95,14 @@ public class CalendarService {
         validateCalendarAccess(calendar);
 
         return scheduleRepository.findDailySchedules(calendar.getId(), date)
-                .stream()
-                .map(ScheduleResponse::from)
-                .collect(Collectors.toList());
+                                 .stream()
+                                 .map(ScheduleResponse::from)
+                                 .collect(Collectors.toList());
     }
 
     // 일정 생성
     @Transactional
-    public ScheduleResponse createSchedule(ScheduleCreateRequest request) {
+    public ScheduleResponse createSchedule(ScheduleCreateRequest request, Long memberId) {
         request.validate();
 
         Calendar calendar = getCurrentCalendar();
@@ -111,41 +111,44 @@ public class CalendarService {
         validateCalendarAccess(calendar);
 
         Schedule schedule = Schedule.builder()
-                .calendar(calendar)
-                .creator(currentMember)
-                .title(request.title())
-                .startTime(request.startTime())
-                .endTime(request.endTime())
-                .description(request.description())
-                .category(request.category())
-                .emoji(request.emoji())
-                .build();
+                                    .calendar(calendar)
+                                    .creator(currentMember)
+                                    .title(request.title())
+                                    .startTime(request.startTime())
+                                    .endTime(request.endTime())
+                                    .description(request.description())
+                                    .category(request.category())
+                                    .emoji(request.emoji())
+                                    .build();
 
         Schedule savedSchedule = scheduleRepository.save(schedule);
+        Long partnerId = memberService.getPartnerIdByMemberId(memberId);
+        notificationService.sendScheduleCreatedNotification(schedule.getId(), memberId, partnerId);
         return ScheduleResponse.from(savedSchedule);
     }
 
     // 일정 수정
     @Transactional
-    public ScheduleResponse updateSchedule(Long scheduleId, ScheduleUpdateRequest request) {
-        request.validate(); // Record의 validate 메서드 호출
+    public ScheduleResponse updateSchedule(Long memberId, Long scheduleId, ScheduleUpdateRequest request) {
+        request.validate();
 
         Calendar calendar = getCurrentCalendar();
         Schedule schedule = findScheduleById(scheduleId);
+        Member member = memberService.findMemberById(memberId);
 
         validateCalendarAccess(calendar);
         validateScheduleAccess(schedule);
         validateScheduleForCalendar(schedule, calendar.getId());
 
-        schedule.update(
-                request.title(),
-                request.startTime(),
-                request.endTime(),
-                request.description(),
-                request.category(),
-                request.emoji()
-        );
+        schedule.update(request.title(),
+                        request.startTime(),
+                        request.endTime(),
+                        request.description(),
+                        request.category(),
+                        request.emoji());
 
+        Long partnerId = memberService.getPartnerIdByMemberId(memberId);
+        notificationService.sendScheduleUpdatedNotification(scheduleId, memberId, partnerId);
         return ScheduleResponse.from(schedule);
     }
 
@@ -162,22 +165,18 @@ public class CalendarService {
 
         scheduleRepository.delete(schedule);
 
-        return ScheduleDeleteResponse.of(
-                scheduleId,
-                calendar.getId(),
-                scheduleTitle,
-                LocalDateTime.now()
-        );
+        return ScheduleDeleteResponse.of(scheduleId, calendar.getId(), scheduleTitle, LocalDateTime.now());
     }
+
 
     private Calendar findCalendarById(Long calendarId) {
         return calendarRepository.findById(calendarId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.CALENDAR_NOT_FOUND));
+                                 .orElseThrow(() -> new BusinessException(ErrorCode.CALENDAR_NOT_FOUND));
     }
 
     private Schedule findScheduleById(Long scheduleId) {
         return scheduleRepository.findById(scheduleId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.SCHEDULE_NOT_FOUND));
+                                 .orElseThrow(() -> new BusinessException(ErrorCode.SCHEDULE_NOT_FOUND));
     }
 
     public Schedule findScheduleById(Long calendarId, Long scheduleId) {
@@ -186,7 +185,9 @@ public class CalendarService {
 
         validateCalendarAccess(calendar);
 
-        if (!schedule.getCalendar().getId().equals(calendarId)) {
+        if (!schedule.getCalendar()
+                     .getId()
+                     .equals(calendarId)) {
             throw new BusinessException(ErrorCode.SCHEDULE_NOT_FOUND);
         }
 
@@ -201,7 +202,8 @@ public class CalendarService {
             throw new BusinessException(ErrorCode.COUPLE_ALREADY_DISCONNECTED);
         }
 
-        if (!currentMember.getCouple().equals(couple)) {
+        if (!currentMember.getCouple()
+                          .equals(couple)) {
             throw new BusinessException(ErrorCode.CALENDAR_ACCESS_DENIED);
         }
     }
@@ -212,20 +214,27 @@ public class CalendarService {
         // SHARED 카테고리인 경우 커플 중 누구나 수정 가능
         if (schedule.getCategory() == ScheduleCategory.SHARED) {
 
-            if (coupleService.isCoupleMember(currentMember, schedule.getCalendar().getCouple().getId())) {
+            if (coupleService.isCoupleMember(
+                    currentMember,
+                    schedule.getCalendar()
+                            .getCouple()
+                            .getId())) {
                 return;
             }
             throw new BusinessException(ErrorCode.SCHEDULE_ACCESS_DENIED);
         }
 
 
-        if (!schedule.getCreator().equals(currentMember)) {
+        if (!schedule.getCreator()
+                     .equals(currentMember)) {
             throw new BusinessException(ErrorCode.SCHEDULE_ACCESS_DENIED);
         }
     }
 
     private void validateScheduleForCalendar(Schedule schedule, Long calendarId) {
-        if (!schedule.getCalendar().getId().equals(calendarId)) {
+        if (!schedule.getCalendar()
+                     .getId()
+                     .equals(calendarId)) {
             throw new BusinessException(ErrorCode.SCHEDULE_NOT_FOUND);
         }
     }
@@ -233,8 +242,10 @@ public class CalendarService {
     // 현재 사용자의 캘린더 조회
     private Calendar getCurrentCalendar() {
         Member currentMember = memberService.getCurrentMember();
+
         return calendarRepository.findByCouple(currentMember.getCouple())
-                .orElseThrow(() -> new BusinessException(ErrorCode.CALENDAR_NOT_FOUND));
+                                 .orElseThrow(() -> new BusinessException(ErrorCode.CALENDAR_NOT_FOUND));
     }
+
 
 }

--- a/backend/src/main/java/com/kongdak/domain/couple/service/CoupleService.java
+++ b/backend/src/main/java/com/kongdak/domain/couple/service/CoupleService.java
@@ -1,8 +1,8 @@
 package com.kongdak.domain.couple.service;
 
-import com.kongdak.domain.couple.dto.request.CoupleMatchRequest;
 import com.kongdak.domain.calendar.entity.Calendar;
 import com.kongdak.domain.calendar.repository.CalendarRepository;
+import com.kongdak.domain.couple.dto.request.CoupleMatchRequest;
 import com.kongdak.domain.couple.dto.response.CoupleDisconnectResponse;
 import com.kongdak.domain.couple.dto.response.CoupleResponse;
 import com.kongdak.domain.couple.dto.response.CoupleRestoreResponse;
@@ -15,9 +15,7 @@ import com.kongdak.domain.member.dto.response.MatchRequestResponse;
 import com.kongdak.domain.member.entity.Member;
 import com.kongdak.domain.member.repository.MemberRepository;
 import com.kongdak.domain.member.service.MemberService;
-import com.kongdak.domain.notification.entity.NotificationEvent;
-import com.kongdak.domain.notification.entity.NotificationType;
-import com.kongdak.domain.notification.service.SseEmitterService;
+import com.kongdak.domain.notification.service.NotificationService;
 import com.kongdak.global.exception.BusinessException;
 import com.kongdak.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -40,7 +38,8 @@ public class CoupleService {
     private final MemberRepository memberRepository;
     private final CalendarRepository calendarRepository;
     private final CoupleMatchRedisRepository coupleMatchRedisRepository;
-    private final SseEmitterService sseEmitterService;
+    private final NotificationService notificationService;
+
     // 연결 코드 발급
     public String getConnectCode(Long memberId) {
         return coupleMatchRedisRepository.findCodeByMemberId(memberId)
@@ -59,13 +58,7 @@ public class CoupleService {
         String requestId = String.format("%06d", new Random().nextInt(1000000));
         coupleMatchRedisRepository.saveMatchRequest(requestId, requesterId, targetId);
 
-        // SSE로 상대방에게 알림 전송
-        NotificationEvent notification = NotificationEvent.of(
-                NotificationType.COUPLE_MATCH_REQUEST,
-                requestId,
-                requesterId
-        );
-        sseEmitterService.sendToMember(targetId, notification);
+        notificationService.sendCoupleRequestNotification(requestId, requesterId, targetId);
 
         return new MatchRequestResponse(
                 requestId,
@@ -92,14 +85,7 @@ public class CoupleService {
         // 매칭 요청 삭제
         coupleMatchRedisRepository.deleteMatchRequest(requestId);
 
-//        // 양쪽 모두에게 매칭 성공 알림
-        NotificationEvent notification = NotificationEvent.of(
-                NotificationType.COUPLE_MATCH_ACCEPTED,
-                request.requesterId(),
-                memberId
-        );
-        sseEmitterService.sendToMember(request.requesterId(), notification);
-        sseEmitterService.sendToMember(memberId, notification);
+        notificationService.sendCoupleAcceptedNotification(memberId, request.requesterId());
 
         return MatchAcceptResponse.of(request.requesterId(), memberId, matchedAt);
     }
@@ -114,14 +100,7 @@ public class CoupleService {
         }
 
         coupleMatchRedisRepository.deleteMatchRequest(requestId);
-
-//        // 요청자에게 거절 알림
-        NotificationEvent notification = NotificationEvent.of(
-                NotificationType.COUPLE_MATCH_REJECTED,
-                request.requesterId(),
-                request.targetId()
-        );
-        sseEmitterService.sendToMember(request.requesterId(), notification);
+        notificationService.sendCoupleRejectedNotification(memberId, request.requesterId());
 
         return MatchRejectResponse.of(
                 request.requesterId(),

--- a/backend/src/main/java/com/kongdak/domain/dailyquestion/service/DailyQuestionService.java
+++ b/backend/src/main/java/com/kongdak/domain/dailyquestion/service/DailyQuestionService.java
@@ -17,6 +17,7 @@ import com.kongdak.domain.dailyquestion.repository.DailyAnswerRepository;
 import com.kongdak.domain.dailyquestion.repository.DailyQuestionRepository;
 import com.kongdak.domain.member.entity.Member;
 import com.kongdak.domain.member.repository.MemberRepository;
+import com.kongdak.domain.notification.service.NotificationService;
 import com.kongdak.global.exception.BusinessException;
 import com.kongdak.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -39,6 +40,7 @@ public class DailyQuestionService {
     private final AnswerEmojiRepository answerEmojiRepository;
     private final MemberRepository memberRepository;
     private final CoupleRepository coupleRepository;
+    private final NotificationService notificationService;
 
     // 오늘의 질문 조회
     public DailyQuestionResponse getDailyQuestion(Long memberId) {
@@ -82,6 +84,9 @@ public class DailyQuestionService {
         if (dailyAnswerRepository.findByQuestionIdAndMemberId(questionId, memberId).isPresent()) {
             throw new BusinessException(ErrorCode.ALREADY_ANSWERED);
         }
+
+        Long partnerId = getPartnerIdByMemberId(memberId);
+        notificationService.sendQuestionAnsweredNotification(questionId, memberId, partnerId);
 
         DailyAnswer answer = DailyAnswer.builder()
                 .question(question)
@@ -147,6 +152,8 @@ public class DailyQuestionService {
                                              .emoji(request.emoji())
                                              .build();
 
+        Long partnerId = getPartnerIdByMemberId(memberId);
+        notificationService.sendDailyQuestionEmojiNotification(answerId, memberId, partnerId);
         AnswerEmoji savedEmoji = answerEmojiRepository.save(answerEmoji);
         return AnswerEmojiResponse.from(savedEmoji);
     }
@@ -165,6 +172,9 @@ public class DailyQuestionService {
         if (answers.size() != 2) {
             throw new BusinessException(ErrorCode.BOTH_ANSWERS_REQUIRED);
         }
+
+        Long partnerId = getPartnerIdByMemberId(memberId);
+        notificationService.sendAnswerRepliedNotification(questionId, memberId, partnerId);
 
         AnswerReply reply = AnswerReply.builder()
                                        .member(member)
@@ -273,5 +283,17 @@ public class DailyQuestionService {
         boolean bothAnswered = answers.size() == 2;
 
         return DailyAnswerUpdateResponse.from(answer, bothAnswered, memberId);
+    }
+
+    private Couple getCoupleByMemberId(Long memberId) {
+        return coupleRepository.findByMemberId(memberId)
+                               .orElseThrow(() -> new BusinessException(ErrorCode.COUPLE_NOT_FOUND));
+    }
+    private Long getPartnerIdByMemberId(Long memberId) {
+        Couple couple = getCoupleByMemberId(memberId);
+
+        return memberRepository.findByCoupleAndIdNot(couple, memberId)
+                               .map(Member::getId)
+                               .orElseThrow(() -> new BusinessException(ErrorCode.PARTNER_NOT_FOUND));
     }
 }

--- a/backend/src/main/java/com/kongdak/domain/diary/service/DiaryService.java
+++ b/backend/src/main/java/com/kongdak/domain/diary/service/DiaryService.java
@@ -18,6 +18,7 @@ import com.kongdak.domain.diary.repository.DiaryPhotoRepository;
 import com.kongdak.domain.diary.repository.DiaryRepository;
 import com.kongdak.domain.member.entity.Member;
 import com.kongdak.domain.member.repository.MemberRepository;
+import com.kongdak.domain.notification.service.NotificationService;
 import com.kongdak.global.exception.BusinessException;
 import com.kongdak.global.exception.ErrorCode;
 import com.kongdak.global.redis.RedisLockRepository;
@@ -50,6 +51,7 @@ public class DiaryService {
     private final CoupleRepository coupleRepository;
     private final RedisLockRepository redisLockRepository;
     private final S3Service s3Service;
+    private final NotificationService notificationService;
 
     @Transactional
     public Long createDiary(Long memberId, CreateDiaryRequest request) {
@@ -94,7 +96,13 @@ public class DiaryService {
             });
         }
 
-        return diaryRepository.save(diary).getId();
+        // 일기 저장
+        Diary savedDiary = diaryRepository.save(diary);
+        // 알림 전송
+        Long partnerId = getPartnerIdByMemberId(memberId);
+        notificationService.sendDiaryCreatedNotification(savedDiary.getId(), memberId, partnerId);
+
+        return savedDiary.getId();
     }
 
     @Transactional
@@ -304,5 +312,14 @@ public class DiaryService {
                     .build();
             diary.addDecoration(decoration);
         });
+    }
+
+
+    private Long getPartnerIdByMemberId(Long memberId) {
+        Couple couple = getCoupleByMemberId(memberId);
+
+        return memberRepository.findByCoupleAndIdNot(couple, memberId)
+                               .map(Member::getId)
+                               .orElseThrow(() -> new BusinessException(ErrorCode.PARTNER_NOT_FOUND));
     }
 }

--- a/backend/src/main/java/com/kongdak/domain/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/kongdak/domain/member/repository/MemberRepository.java
@@ -13,20 +13,9 @@ import java.util.Optional;
 
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
-
     Optional<Member> findByEmail(String email);
-    Optional<Member> findByEmailAndOauthProvider(String email, OAuthProvider provider);
 
     boolean existsByEmail(String email);
-
-    @Query("SELECT m FROM Member m WHERE m.isActive = true AND m.couple IS NULL")
-    List<Member> findActiveUnconnectedMembers();
-
-    @Query("SELECT m.id FROM Member m WHERE m.couple = :couple AND m.id != :memberId")
-    Optional<Long> findPartnerIdByCoupleAndMemberIdNot(
-            @Param("couple") Couple couple,
-            @Param("memberId") Long memberId
-    );
 
     // 특정 커플에 속한 모든 멤버 조회
     @Query("SELECT m FROM Member m WHERE m.couple = :couple")
@@ -38,4 +27,18 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
             @Param("couple") Couple couple,
             @Param("memberId") Long memberId
     );
+
+    Optional<Member> findByCoupleAndIdNot(Couple couple, Long memberId);
+
+    //            @Param("memberId") Long memberId
+    //    Optional<Member> findByEmailAndOauthProvider(String email, OAuthProvider provider);
+    //
+    //    @Query("SELECT m FROM Member m WHERE m.isActive = true AND m.couple IS NULL")
+    //    List<Member> findActiveUnconnectedMembers();
+    //
+    //    @Query("SELECT m.id FROM Member m WHERE m.couple = :couple AND m.id != :memberId")
+    //    Optional<Long> findPartnerIdByCoupleAndMemberIdNot(
+    //            @Param("couple") Couple couple,
+
+    //    );
 }

--- a/backend/src/main/java/com/kongdak/domain/member/service/MemberService.java
+++ b/backend/src/main/java/com/kongdak/domain/member/service/MemberService.java
@@ -1,5 +1,6 @@
 package com.kongdak.domain.member.service;
 
+import com.kongdak.domain.couple.entity.Couple;
 import com.kongdak.domain.member.dto.request.MemberCreateRequest;
 import com.kongdak.domain.member.dto.response.ActivateResponse;
 import com.kongdak.domain.member.dto.response.DeactivateResponse;
@@ -104,6 +105,17 @@ public class MemberService {
         }
 
         return MemberResponse.from(member, partner);
+    }
+
+    public Long getPartnerIdByMemberId(Long memberId){
+        Member member = memberRepository.findById(memberId)
+                                        .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+
+        Couple couple = member.getCouple();
+
+        return memberRepository.findByCoupleAndIdNot(couple, memberId)
+                               .map(Member::getId)
+                               .orElseThrow(() -> new BusinessException(ErrorCode.PARTNER_NOT_FOUND));
     }
 
 

--- a/backend/src/main/java/com/kongdak/domain/notification/entity/NotificationEvent.java
+++ b/backend/src/main/java/com/kongdak/domain/notification/entity/NotificationEvent.java
@@ -1,19 +1,22 @@
 package com.kongdak.domain.notification.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
 
 @Entity
 @Table(name = "notification_event")
 @Getter
-@Builder
 @NoArgsConstructor
-@AllArgsConstructor
 public class NotificationEvent {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -26,17 +29,14 @@ public class NotificationEvent {
     @Column(nullable = false)
     private String message; // 알림 메시지
 
-    @Column(nullable = true)
-    private String requestId; // 커플 요청 ID
-
     @Column
     private Long requesterId; // 요청자 ID
 
     @Column(nullable = false)
     private Long receiverId; // 수신자 ID
 
-    @Transient //DB에 저장하지 않을 추가 데이터
-    private Object data; //추가 데이터 (필요시)
+    @Column(name = "additional_data", columnDefinition = "TEXT")
+    private String additionalDataJson; // 추가 데이터 (JSON 문자열)
 
     @Column(name = "is_read", nullable = false)
     private boolean isRead; // 읽음 상태
@@ -44,48 +44,148 @@ public class NotificationEvent {
     @Column(nullable = false)
     private LocalDateTime timestamp; //생성 시간
 
-    public static NotificationEvent of(NotificationType type, Long receiverId) {
-        return NotificationEvent.builder()
+    @Transient
+    @JsonIgnore
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    // Builder 패턴으로 객체 생성
+    @Builder(builderMethodName = "builder")
+    private NotificationEvent(
+            Long id,
+            NotificationType type,
+            String message,
+            Long requesterId,
+            Long receiverId,
+            String additionalDataJson,
+            boolean isRead,
+            LocalDateTime timestamp
+    ) {
+        this.id = id;
+        this.type = type;
+        this.message = message != null ? message : type.getDefaultMessage();
+        this.requesterId = requesterId;
+        this.receiverId = receiverId;
+        this.additionalDataJson = additionalDataJson;
+        this.isRead = isRead;
+        this.timestamp = timestamp != null ? timestamp : LocalDateTime.now();
+    }
+    public static class NotificationEventBuilder {
+        private Map<String, Object> dataMap = new HashMap<>();
+
+        // 메시지가 null이면 타입의 기본 메시지 사용
+        public NotificationEventBuilder message(String message) {
+            this.message = message;
+            return this;
+        }
+
+        // 현재 시간으로 타임스탬프 설정
+        public NotificationEventBuilder timestamp(LocalDateTime timestamp) {
+            this.timestamp = timestamp != null ? timestamp : LocalDateTime.now();
+            return this;
+        }
+
+        // 읽지 않음으로 기본 설정
+        public NotificationEventBuilder isRead(boolean isRead) {
+            this.isRead = isRead;
+            return this;
+        }
+
+        // 추가 데이터 설정
+        public NotificationEventBuilder addData(String key, Object value) {
+            if (this.dataMap == null) {
+                this.dataMap = new HashMap<>();
+            }
+            this.dataMap.put(key, value);
+            return this;
+        }
+
+
+    }
+    // 정적 생성 메서드들
+    public static NotificationEventBuilder create(NotificationType type, Long receiverId) {
+        return builder()
                 .type(type)
-                .message(type.getDefaultMessage())
                 .receiverId(receiverId)
                 .isRead(false)
-                .timestamp(LocalDateTime.now())
-                .build();
+                .timestamp(LocalDateTime.now());
+    }
+
+    public static NotificationEventBuilder create(NotificationType type, Long requesterId, Long receiverId) {
+        return builder()
+                .type(type)
+                .requesterId(requesterId)
+                .receiverId(receiverId)
+                .isRead(false)
+                .timestamp(LocalDateTime.now());
+    }
+
+    public static NotificationEventBuilder createWithRequest(NotificationType type, String requestId, Long requesterId, Long receiverId) {
+        return builder()
+                .type(type)
+                .requesterId(requesterId)
+                .receiverId(receiverId)
+                .addData("requestId", requestId)  // requestId를 추가 데이터로 이동
+                .isRead(false)
+                .timestamp(LocalDateTime.now());
+    }
+
+    // 기존 팩토리 메서드들 (하위 호환성)
+    public static NotificationEvent of(NotificationType type, Long receiverId) {
+        return create(type, receiverId).build();
     }
 
     public static NotificationEvent of(NotificationType type, Long requesterId, Long receiverId) {
-        return NotificationEvent.builder()
-                .type(type)
-                .message(type.getDefaultMessage())
-                .requesterId(requesterId)
-                .receiverId(receiverId)
-                .isRead(false)
-                .timestamp(LocalDateTime.now())
-                .build();
+        return create(type, requesterId, receiverId).build();
     }
 
     public static NotificationEvent of(NotificationType type, String message, Long receiverId) {
-        return NotificationEvent.builder()
-                .type(type)
+        return create(type, receiverId)
                 .message(message)
-                .receiverId(receiverId)
-                .isRead(false)
-                .timestamp(LocalDateTime.now())
                 .build();
     }
 
-    // 커플 요청 관련 알림용 (requestId 포함)
     public static NotificationEvent ofRequest(NotificationType type, String requestId, Long requesterId, Long receiverId) {
-        return NotificationEvent.builder()
-                .type(type)
-                .message(type.getDefaultMessage())
-                .requestId(requestId)
-                .requesterId(requesterId)
-                .receiverId(receiverId)
-                .isRead(false)
-                .timestamp(LocalDateTime.now())
-                .build();
+        return createWithRequest(type, requestId, requesterId, receiverId).build();
+    }
+
+    // 추가 데이터 관련 메서드
+    public void addData(String key, Object value) {
+        try {
+            Map<String, Object> dataMap = getDataMap();
+            dataMap.put(key, value);
+            this.additionalDataJson = objectMapper.writeValueAsString(dataMap);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed to add data to notification", e);
+        }
+    }
+
+    public Object getData(String key) {
+        Map<String, Object> dataMap = getDataMap();
+        return dataMap.get(key);
+    }
+
+    public Map<String, Object> getAllData() {
+        return getDataMap();
+    }
+
+    // requestId를 추가 데이터에서 가져오는 편의 메서드 (하위 호환성)
+    public String getRequestId() {
+        Object requestId = getData("requestId");
+        return requestId != null ? requestId.toString() : null;
+    }
+
+    @JsonIgnore
+    private Map<String, Object> getDataMap() {
+        if (additionalDataJson == null || additionalDataJson.isEmpty()) {
+            return new HashMap<>();
+        }
+
+        try {
+            return objectMapper.readValue(additionalDataJson,
+                                          new TypeReference<HashMap<String, Object>>() {});
+        } catch (JsonProcessingException e) {
+            return new HashMap<>();
+        }
     }
 
     // 읽음 처리 메서드

--- a/backend/src/main/java/com/kongdak/domain/notification/entity/NotificationType.java
+++ b/backend/src/main/java/com/kongdak/domain/notification/entity/NotificationType.java
@@ -23,7 +23,7 @@ public enum NotificationType {
     DAILY_QUESTION_NEW("오늘의 질문이 도착했습니다."),
     DAILY_QUESTION_ANSWERED("상대방이 질문에 답변했습니다."),
     DAILY_QUESTION_REPLIED("답변에 댓글이 달렸습니다."),
-
+    DAILY_QUESTION_EMOJI_CREATED("답변에 이모지가 달렸습니다."),
     // 버킷리스트
     BUCKET_CREATED("버킷리스트에 새 항목이 추가되었습니다."),
     BUCKET_COMPLETED("버킷리스트 항목이 완료되었습니다."),

--- a/backend/src/main/java/com/kongdak/domain/notification/service/NotificationService.java
+++ b/backend/src/main/java/com/kongdak/domain/notification/service/NotificationService.java
@@ -51,10 +51,7 @@ public class NotificationService {
      * 알림 읽음 처리
      */
     @Transactional
-    public void markAsRead(
-            Long notificationId,
-            Long memberId
-    ) {
+    public void markAsRead(Long notificationId, Long memberId) {
         notificationRepository.findByIdAndReceiverId(notificationId, memberId)
                               .ifPresent(notification -> {
                                   notification.markAsRead();
@@ -66,12 +63,12 @@ public class NotificationService {
      * 커플 연결 요청 알림 전송
      */
     @Transactional
-    public void sendCoupleRequestNotification(
-            String requestId,
-            Long requesterId,
-            Long receiverId
-    ) {
-        NotificationEvent notification = NotificationEvent.ofRequest(NotificationType.COUPLE_MATCH_REQUEST, requestId, requesterId, receiverId);
+    public void sendCoupleRequestNotification(String requestId, Long requesterId, Long receiverId) {
+        NotificationEvent notification = NotificationEvent.createWithRequest(NotificationType.COUPLE_MATCH_REQUEST,
+                                                                             requestId,
+                                                                             requesterId,
+                                                                             receiverId)
+                                                          .build();
         sendNotification(notification);
     }
 
@@ -79,11 +76,13 @@ public class NotificationService {
      * 커플 연결 수락 알림 전송
      */
     @Transactional
-    public void sendCoupleAcceptedNotification(
-            Long requesterId,
-            Long receiverId
-    ) {
-        NotificationEvent notification = NotificationEvent.of(NotificationType.COUPLE_MATCH_ACCEPTED, receiverId, requesterId);
+    public void sendCoupleAcceptedNotification(Long requesterId, Long receiverId) {
+        NotificationEvent notification = NotificationEvent.create(NotificationType.COUPLE_MATCH_ACCEPTED,
+                                                                  requesterId,
+                                                                  receiverId
+                                                          )
+                                                          .build();
+
         sendNotification(notification);
     }
 
@@ -91,11 +90,12 @@ public class NotificationService {
      * 커플 연결 거절 알림 전송
      */
     @Transactional
-    public void sendCoupleRejectedNotification(
-            Long requesterId,
-            Long receiverId
-    ) {
-        NotificationEvent notification = NotificationEvent.of(NotificationType.COUPLE_MATCH_REJECTED, receiverId, requesterId);
+    public void sendCoupleRejectedNotification(Long requesterId, Long receiverId) {
+        NotificationEvent notification = NotificationEvent.create(NotificationType.COUPLE_MATCH_REJECTED,
+                                                                  requesterId,
+                                                                  receiverId
+                                                          )
+                                                          .build();
         sendNotification(notification);
     }
 
@@ -103,11 +103,161 @@ public class NotificationService {
      * 콕 찌르기 알림 전송
      */
     @Transactional
-    public void sendPokeNotification(
-            Long senderId,
-            Long receiverId
-    ) {
-        NotificationEvent notification = NotificationEvent.of(NotificationType.POKE, senderId, receiverId);
+    public void sendPokeNotification(Long senderId, Long receiverId) {
+        NotificationEvent notification = NotificationEvent.create(NotificationType.POKE, senderId, receiverId)
+                                                          .build();
+        sendNotification(notification);
+    }
+
+    /**
+     * 기념일 알림 전송
+     */
+    @Transactional
+    public void sendAnniversaryNotification(Long memberId1, Long memberId2) {
+
+
+        NotificationEvent notification1 = NotificationEvent.create(NotificationType.COUPLE_ANNIVERSARY, memberId1)
+                                                           .build();
+        NotificationEvent notification2 = NotificationEvent.create(NotificationType.COUPLE_ANNIVERSARY, memberId2)
+                                                           .build();
+
+        sendNotification(notification1);
+        sendNotification(notification2);
+    }
+
+
+    /**
+     * 일정 관련 알림 전송 (생성, 수정)
+     */
+    private NotificationEvent createScheduleNotification(NotificationType type,
+                                                         Long scheduleId,
+                                                         Long actorId,
+                                                         Long partnerId) {
+        return NotificationEvent.create(type, actorId, partnerId)
+                                .addData("scheduleId", scheduleId.toString())
+                                .build();
+    }
+
+    /**
+     * 일정 생성 알림 전송
+     */
+    @Transactional
+    public void sendScheduleCreatedNotification(Long scheduleId, Long creatorId, Long partnerId) {
+        NotificationEvent notification = createScheduleNotification(NotificationType.SCHEDULE_CREATED,
+                                                                    scheduleId,
+                                                                    creatorId,
+                                                                    partnerId);
+        sendNotification(notification);
+    }
+
+    /**
+     * 일정 수정 알림 전송
+     */
+    @Transactional
+    public void sendScheduleUpdatedNotification(Long scheduleId, Long updaterId, Long partnerId) {
+        NotificationEvent notification = createScheduleNotification(NotificationType.SCHEDULE_UPDATED,
+                                                                    scheduleId,
+                                                                    updaterId,
+                                                                    partnerId);
+        sendNotification(notification);
+    }
+
+    /**
+     * 일정 리마인더 알림 전송 (스케줄러에서 호출)
+     */
+    @Transactional
+    public void sendScheduleReminderNotification(Long scheduleId, List<Long> memberIds) {
+        for (Long memberId : memberIds) {
+            NotificationEvent notification = NotificationEvent.create(NotificationType.SCHEDULE_REMINDER, memberId)
+                                                              .addData("scheduleId", scheduleId.toString())
+                                                              .build();
+            sendNotification(notification);
+        }
+    }
+
+
+    /**
+     * 일기 작성 알림 전송
+     */
+    @Transactional
+    public void sendDiaryCreatedNotification(Long diaryId, Long authorId, Long partnerId) {
+        NotificationEvent notification = NotificationEvent.create(NotificationType.DIARY_CREATED, authorId, partnerId)
+                                                          .addData("diaryId", diaryId.toString())
+                                                          .build();
+        sendNotification(notification);
+    }
+
+    /**
+     * 오늘의 질문 이모지 반응 알림 전송
+     */
+    @Transactional
+    public void sendDailyQuestionEmojiNotification(Long answerId, Long reactorId, Long authorId) {
+        NotificationEvent notification = NotificationEvent.create(NotificationType.DAILY_QUESTION_EMOJI_CREATED, reactorId, authorId)
+                                                          .addData("answerId", answerId.toString())
+                                                          .build();
+        sendNotification(notification);
+    }
+
+    /**
+     * 오늘의 질문 알림 전송
+     */
+    @Transactional
+    public void sendDailyQuestionNotification(Long questionId, List<Long> memberIds) {
+        for (Long memberId : memberIds) {
+            NotificationEvent notification = NotificationEvent.create(NotificationType.DAILY_QUESTION_NEW, memberId)
+                                                              .addData("questionId", questionId.toString())
+                                                              .build();
+            sendNotification(notification);
+        }
+    }
+
+    /**
+     * 질문 답변 알림 전송
+     */
+    @Transactional
+    public void sendQuestionAnsweredNotification(Long questionId, Long answererId, Long partnerId) {
+        NotificationEvent notification = NotificationEvent.create(NotificationType.DAILY_QUESTION_ANSWERED,
+                                                                  answererId,
+                                                                  partnerId)
+                                                          .addData("questionId", questionId.toString())
+                                                          .build();
+        sendNotification(notification);
+    }
+
+    /**
+     * 답변 댓글 알림 전송
+     */
+    @Transactional
+    public void sendAnswerRepliedNotification(Long questionId, Long replierId, Long answererId) {
+        NotificationEvent notification = NotificationEvent.create(NotificationType.DAILY_QUESTION_REPLIED,
+                                                                  replierId,
+                                                                  answererId)
+                                                          .addData("questionId", questionId.toString())
+                                                          .build();
+        sendNotification(notification);
+    }
+
+    /**
+     * 버킷리스트 생성 알림 전송
+     */
+    @Transactional
+    public void sendBucketCreatedNotification(Long bucketId, Long creatorId, Long partnerId) {
+        NotificationEvent notification = NotificationEvent.create(NotificationType.BUCKET_CREATED, creatorId, partnerId)
+                                                          .addData("bucketId", bucketId.toString())
+                                                          .build();
+        sendNotification(notification);
+    }
+
+    /**
+     * 버킷리스트 완료 알림 전송
+     */
+    @Transactional
+    public void sendBucketCompletedNotification(Long bucketId, Long completerId, Long partnerId) {
+        NotificationEvent notification = NotificationEvent.create(NotificationType.BUCKET_COMPLETED,
+                                                                  completerId,
+                                                                  partnerId)
+                                                          .addData("bucketId", bucketId.toString())
+                                                          .build();
         sendNotification(notification);
     }
 }


### PR DESCRIPTION
# 알림(Notification) SSE 구현 및 서비스 확장

## 주요 변경사항
- 다양한 이벤트 발생 시 실시간 알림 기능 구현
- 기존 Builder 패턴을 커스텀하여 알림 생성 로직 개선
- 파트너 ID 조회 로직 추가

## 구현 내용

### 알림 시스템 개선
- `NotificationEvent` 클래스에 커스텀 빌더 패턴 적용
  - 추가 데이터(additionalData) 설정을 위한 메서드 체이닝 지원
  - JSON 형태로 저장하여 유연한 데이터 구조 제공
- `NotificationType` 확장 
  - 데일리 질문 이모지 알림 유형 추가

### 알림 전송 로직 추가
다음 기능에 알림 전송 로직이 추가되었습니다:
1. **캘린더 관련 알림**
   - 일정 생성/수정/리마인더
2. **데일리 질문 관련 알림**
   - 질문 응답/이모지 반응/댓글
3. **버킷리스트 관련 알림**
   - 버킷리스트 생성/완료
4. **일기 관련 알림**
   - 일기 작성

### 파트너 ID 조회 로직 추가
- `MemberService`에 파트너 ID를 조회하는 메서드 추가
  - 현재는 MemberRepository → CoupleRepository → MemberRepository를 거쳐야 함
  - 추후 Member 엔티티에 coupleId 필드를 추가하여 조회 성능 개선 검토 중

## 기술적 고려사항
- 코드 중복을 줄이기 위해 알림 생성 로직을 캡슐화
- 다양한 알림 유형에 맞는 추가 데이터를 전달할 수 있도록 유연한 구조 설계
- 반복되는 알림 전송 패턴을 통합하여 유지보수성 향상

## 추후 개선 사항
- Member 엔티티에 coupleId 필드 추가를 통한 쿼리 최적화 검토
- 알림 수신 설정 기능 추가 (사용자가 알림 유형별로 설정 가능하도록)
- 일부 알림은 본인에게도 전송하는 방안 검토 (현재는 상대방에게만 전송)